### PR TITLE
Refactoring. Breaking change! 

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,7 +3,6 @@ use std::hash::Hash;
 use egui::{
     ahash::{HashMap, HashMapExt},
     collapsing_header::paint_default_icon,
-    emath::Rot2,
     epaint::Shadow,
     pos2, vec2, Align, Color32, Frame, Layout, Modifiers, PointerButton, Pos2, Rect, Sense, Shape,
     Stroke, Style, Ui, Vec2,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -208,10 +208,10 @@ impl<T> Snarl<T> {
 
                 let pin_size = style
                     .pin_size
-                    .unwrap_or_else(|| node_style.spacing.interact_size.y * 0.5);
+                    .unwrap_or(node_style.spacing.interact_size.y * 0.5);
 
                 let wire_frame_size = style.wire_frame_size.unwrap_or(pin_size * 5.0);
-                let wire_width = style.wire_width.unwrap_or_else(|| pin_size * 0.2);
+                let wire_width = style.wire_width.unwrap_or(pin_size * 0.2);
                 let header_drag_space = style.header_drag_space.unwrap_or_else(|| {
                     vec2(node_style.spacing.icon_width, node_style.spacing.icon_width)
                 });
@@ -293,7 +293,7 @@ impl<T> Snarl<T> {
                     let inputs = (0..inputs_count)
                         .map(|idx| {
                             InPin::new(
-                                &self,
+                                self,
                                 InPinId {
                                     node: node_idx,
                                     input: idx,
@@ -305,7 +305,7 @@ impl<T> Snarl<T> {
                     let outputs = (0..outputs_count)
                         .map(|idx| {
                             OutPin::new(
-                                &self,
+                                self,
                                 OutPinId {
                                     node: node_idx,
                                     output: idx,
@@ -333,7 +333,7 @@ impl<T> Snarl<T> {
                     // Rect for node + frame margin.
                     let node_frame_rect = node_frame.total_margin().expand_rect(node_rect);
 
-                    let ref mut node_ui = ui.child_ui_with_id_source(
+                    let node_ui = &mut ui.child_ui_with_id_source(
                         node_frame_rect,
                         Layout::top_down(Align::Center),
                         node_id,
@@ -348,7 +348,7 @@ impl<T> Snarl<T> {
                             header_frame.total_margin().expand_rect(header_rect);
 
                         // Show node's header
-                        let ref mut header_ui = ui.child_ui_with_id_source(
+                        let header_ui = &mut ui.child_ui_with_id_source(
                             header_frame_rect,
                             Layout::top_down(Align::Center),
                             node_id,
@@ -436,7 +436,7 @@ impl<T> Snarl<T> {
                                 pos2(f32::max(node_rect.max.x, header_rect.max.x), f32::INFINITY),
                             );
 
-                            let ref mut inputs_ui = ui.child_ui_with_id_source(
+                            let inputs_ui = &mut ui.child_ui_with_id_source(
                                 pins_rect,
                                 Layout::top_down(Align::Center),
                                 (node_id, "inputs"),
@@ -494,7 +494,7 @@ impl<T> Snarl<T> {
                                             if snarl_state.has_new_wires() {
                                                 snarl_state.remove_new_wire_in(in_pin.id);
                                             } else {
-                                                let _ = viewer.drop_inputs(&in_pin, self);
+                                                viewer.drop_inputs(&in_pin, self);
                                             }
                                         }
                                         if r.drag_started_by(PointerButton::Primary) {
@@ -542,7 +542,7 @@ impl<T> Snarl<T> {
 
                             // Outputs are placed under the header and must not go outside of the header frame.
 
-                            let ref mut outputs_ui = ui.child_ui_with_id_source(
+                            let outputs_ui = &mut ui.child_ui_with_id_source(
                                 pins_rect,
                                 Layout::top_down(Align::Center),
                                 (node_id, "outputs"),
@@ -601,7 +601,7 @@ impl<T> Snarl<T> {
                                             if snarl_state.has_new_wires() {
                                                 snarl_state.remove_new_wire_out(out_pin.id);
                                             } else {
-                                                let _ = viewer.drop_outputs(&out_pin, self);
+                                                viewer.drop_outputs(&out_pin, self);
                                             }
                                         }
                                         if r.drag_started_by(PointerButton::Primary) {
@@ -741,10 +741,10 @@ impl<T> Snarl<T> {
 
                 if let Some(wire) = hovered_wire {
                     if bg_r.clicked_by(PointerButton::Secondary) {
-                        let out_pin = OutPin::new(&self, wire.out_pin);
-                        let in_pin = InPin::new(&self, wire.in_pin);
+                        let out_pin = OutPin::new(self, wire.out_pin);
+                        let in_pin = InPin::new(self, wire.in_pin);
 
-                        let _ = viewer.disconnect(&out_pin, &in_pin, self);
+                        viewer.disconnect(&out_pin, &in_pin, self);
                     }
 
                     // Background is not hovered then.
@@ -754,10 +754,8 @@ impl<T> Snarl<T> {
                     bg_r.triple_clicked = [false; egui::NUM_POINTER_BUTTONS];
                 }
 
-                if bg_r.hovered() {
-                    if bg_r.dragged_by(PointerButton::Primary) {
-                        snarl_state.pan(-bg_r.drag_delta());
-                    }
+                if bg_r.hovered() && bg_r.dragged_by(PointerButton::Primary) {
+                    snarl_state.pan(-bg_r.drag_delta());
                 }
                 bg_r.context_menu(|ui| {
                     viewer.graph_menu(
@@ -853,7 +851,7 @@ impl<T> Snarl<T> {
                     match (new_wires, pin_hovered) {
                         (Some(NewWires::In(in_pins)), Some(AnyPin::Out(out_pin))) => {
                             for in_pin in in_pins {
-                                let _ = viewer.connect(
+                                viewer.connect(
                                     &OutPin::new(self, out_pin),
                                     &InPin::new(self, in_pin),
                                     self,
@@ -862,7 +860,7 @@ impl<T> Snarl<T> {
                         }
                         (Some(NewWires::Out(out_pins)), Some(AnyPin::In(in_pin))) => {
                             for out_pin in out_pins {
-                                let _ = viewer.connect(
+                                viewer.connect(
                                     &OutPin::new(self, out_pin),
                                     &InPin::new(self, in_pin),
                                     self,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,6 @@ mod wire;
 mod zoom;
 
 use self::{
-    background_pattern::BackgroundPattern,
     pin::draw_pin,
     state::{NewWires, NodeState, SnarlState},
     wire::{draw_wire, hit_wire, mix_colors},
@@ -52,7 +51,7 @@ pub struct SnarlStyle {
     pub collapsible: bool,
 
     pub bg_fill: Option<Color32>,
-    pub bg_pattern: BackgroundPattern,
+    pub bg_pattern: background_pattern::BackgroundPattern,
     pub background_pattern_stroke: Option<Stroke>,
 
     pub min_scale: f32,
@@ -74,7 +73,7 @@ impl SnarlStyle {
             collapsible: true,
 
             bg_fill: None,
-            bg_pattern: BackgroundPattern::new(),
+            bg_pattern: background_pattern::BackgroundPattern::new(),
             background_pattern_stroke: None,
 
             min_scale: 0.1,
@@ -581,7 +580,8 @@ impl<T> Snarl<T> {
                 - header_frame.total_margin().right
                 - pin_size * 0.5;
 
-            if true {
+            // Input/output pin block
+            {
                 if (openness < 1.0 && open) || (openness > 0.0 && !open) {
                     ui.ctx().request_repaint();
                 }
@@ -818,27 +818,6 @@ impl<T> Snarl<T> {
                 //     .debug_rect(header_frame_rect, Color32::GREEN, "header");
                 // ui.painter()
                 //     .debug_rect(pins_clip_rect, Color32::RED, "pins_clip");
-            } else {
-                for in_pin in inputs {
-                    let pin_pos = pos2(input_x, min_pin_y);
-                    input_positions.insert(in_pin.id, (pin_pos, viewer.input_color(&in_pin, node_style, self)));
-
-                    if !self.nodes.contains(node_idx) {
-                        node_state.clear(ui.ctx());
-                        // If removed
-                        return;
-                    }
-                }
-                for out_pin in outputs {
-                    let pin_pos = pos2(output_x, min_pin_y);
-                    output_positions.insert(out_pin.id, (pin_pos, viewer.output_color(&out_pin, node_style, self)));
-
-                    if !self.nodes.contains(node_idx) {
-                        node_state.clear(ui.ctx());
-                        // If removed
-                        return;
-                    }
-                }
             }
         });
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashMap, hash::Hash};
 
 use egui::{
-    collapsing_header::paint_default_icon,
-    epaint::Shadow,
-    pos2, vec2, Align, Color32, Frame, Id, Layout, Modifiers, PointerButton, Pos2, Rect, Sense,
-    Shape, Stroke, Style, Ui, Vec2,
+    collapsing_header::paint_default_icon, epaint::Shadow, pos2, vec2, Align, Color32, Frame, Id,
+    Layout, Modifiers, PointerButton, Pos2, Rect, Sense, Shape, Stroke, Style, Ui, Vec2,
 };
 
 use crate::{InPin, InPinId, Node, OutPin, OutPinId, Snarl};
@@ -54,7 +52,7 @@ pub struct SnarlStyle {
     pub collapsible: bool,
 
     pub bg_fill: Option<Color32>,
-    pub bg_pattern: Option<BackgroundPattern>,
+    pub bg_pattern: BackgroundPattern,
     pub background_pattern_stroke: Option<Stroke>,
 
     pub min_scale: f32,
@@ -76,10 +74,7 @@ impl SnarlStyle {
             collapsible: true,
 
             bg_fill: None,
-            bg_pattern: Some(BackgroundPattern::Grid(background_pattern::Grid::new(
-                vec2(5.0, 5.0),
-                1.0,
-            ))),
+            bg_pattern: BackgroundPattern::new(),
             background_pattern_stroke: None,
 
             min_scale: 0.1,
@@ -119,9 +114,7 @@ impl<T> Snarl<T> {
         viewport: &Rect,
         ui: &mut Ui,
     ) {
-        if let Some(pattern) = &style.bg_pattern {
-            pattern.draw(style, snarl_state, viewport, ui);
-        }
+        style.bg_pattern.draw(style, snarl_state, viewport, ui);
     }
 
     /// Render [`Snarl`] using given viewer and style into the [`Ui`].
@@ -231,17 +224,17 @@ impl<T> Snarl<T> {
                         &mut output_positions,
                         &mut output_colors,
                     );
-                    if let Some(v) = response.node_idx_to_top{
+                    if let Some(v) = response.node_idx_to_top {
                         node_idx_to_top = Some(v);
                     }
-                    if let Some(v) = response.node_moved{
+                    if let Some(v) = response.node_moved {
                         node_moved = Some(v);
                     }
-                    if let Some(v) = response.pin_hovered{
+                    if let Some(v) = response.pin_hovered {
                         pin_hovered = Some(v);
                     }
                     drag_released |= response.drag_released;
-                }   
+                }
 
                 let mut hovered_wire = None;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use egui::{
 
 use crate::{InPin, InPinId, Node, OutPin, OutPinId, Snarl};
 
-mod background_pattern;
+pub mod background_pattern;
 mod pin;
 mod state;
 mod viewer;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -416,6 +416,8 @@ impl<T> Snarl<T> {
         }
     }
 
+    //First step for split big function to parts
+    /// Draw one node. Return Pins info
     #[inline(always)]
     fn draw_node<V>(
         &mut self,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,10 @@
-use std::hash::Hash;
+use std::{collections::HashMap, hash::Hash};
 
 use egui::{
-    ahash::{HashMap, HashMapExt},
     collapsing_header::paint_default_icon,
     epaint::Shadow,
-    pos2, vec2, Align, Color32, Frame, Layout, Modifiers, PointerButton, Pos2, Rect, Sense, Shape,
-    Stroke, Style, Ui, Vec2,
+    pos2, vec2, Align, Color32, Frame, Id, Layout, Modifiers, PointerButton, Pos2, Rect, Sense,
+    Shape, Stroke, Style, Ui, Vec2,
 };
 
 use crate::{InPin, InPinId, Node, OutPin, OutPinId, Snarl};
@@ -105,6 +104,13 @@ struct Input {
     modifiers: Modifiers,
 }
 
+struct DrawNodeResponse {
+    node_moved: Option<(usize, Vec2)>,
+    node_idx_to_top: Option<usize>,
+    drag_released: bool,
+    pin_hovered: Option<AnyPin>,
+}
+
 impl<T> Snarl<T> {
     fn draw_background(
         &mut self,
@@ -169,11 +175,6 @@ impl<T> Snarl<T> {
 
                 let wire_frame_size = style.wire_frame_size.unwrap_or(pin_size * 5.0);
                 let wire_width = style.wire_width.unwrap_or(pin_size * 0.2);
-                let header_drag_space = style.header_drag_space.unwrap_or_else(|| {
-                    vec2(node_style.spacing.icon_width, node_style.spacing.icon_width)
-                });
-
-                let collapsible = style.collapsible;
 
                 let node_frame = Frame::window(&node_style);
                 let header_frame = node_frame.shadow(Shadow::NONE);
@@ -199,6 +200,7 @@ impl<T> Snarl<T> {
                     _ => {}
                 }
 
+                //TODO: May be replace to `HashMap<InPinId, (Pos2, Color32)>?`
                 let mut input_positions = HashMap::new();
                 let mut output_positions = HashMap::new();
 
@@ -210,461 +212,36 @@ impl<T> Snarl<T> {
                 let draw_order = self.draw_order.clone();
                 let mut drag_released = false;
 
-                let mut show_node = |node_idx: usize| {
-                    let Node {
-                        pos,
-                        open,
-                        ref value,
-                    } = self.nodes[node_idx];
-
-                    // Collect pins
-                    let inputs_count = viewer.inputs(value);
-                    let outputs_count = viewer.outputs(value);
-
-                    let node_pos = snarl_state.graph_pos_to_screen(pos, viewport);
-
-                    // Generate persistent id for the node.
-                    let node_id = snarl_id.with(("snarl-node", node_idx));
-
-                    let openness = ui.ctx().animate_bool(node_id, open);
-
-                    let mut node_state = NodeState::load(ui.ctx(), node_id, &node_style.spacing);
-
-                    let node_rect = node_state.node_rect(node_pos);
-
-                    // let header_rect = node_state.header_rect(&node_style.spacing, node_pos);
-                    // let pins_rect =
-                    //     node_state.pins_rect(&header_frame, &node_style.spacing, openness, node_pos);
-
-                    // Interact with node frame.
-                    let r = ui.interact(node_rect, node_id, Sense::click_and_drag());
-
-                    if r.dragged_by(PointerButton::Primary) {
-                        node_moved =
-                            Some((node_idx, snarl_state.screen_vec_to_graph(r.drag_delta())));
-                    }
-                    if r.clicked() || r.dragged() {
-                        node_idx_to_top = Some(node_idx);
-                    }
-
-                    let inputs = (0..inputs_count)
-                        .map(|idx| {
-                            InPin::new(
-                                self,
-                                InPinId {
-                                    node: node_idx,
-                                    input: idx,
-                                },
-                            )
-                        })
-                        .collect::<Vec<_>>();
-
-                    let outputs = (0..outputs_count)
-                        .map(|idx| {
-                            OutPin::new(
-                                self,
-                                OutPinId {
-                                    node: node_idx,
-                                    output: idx,
-                                },
-                            )
-                        })
-                        .collect::<Vec<_>>();
-
-                    r.context_menu(|ui| {
-                        viewer.node_menu(
-                            node_idx,
-                            &inputs,
-                            &outputs,
-                            ui,
-                            snarl_state.scale(),
-                            self,
-                        );
-                    });
-                    if !self.nodes.contains(node_idx) {
-                        node_state.clear(ui.ctx());
-                        // If removed
-                        return;
-                    }
-
-                    // Rect for node + frame margin.
-                    let node_frame_rect = node_frame.total_margin().expand_rect(node_rect);
-
-                    let node_ui = &mut ui.child_ui_with_id_source(
-                        node_frame_rect,
-                        Layout::top_down(Align::Center),
-                        node_id,
-                    );
-                    node_ui.set_style(node_style.clone());
-
-                    node_frame.show(node_ui, |ui| {
-                        // Render header frame.
-                        let mut header_rect = node_rect;
-
-                        let mut header_frame_rect =
-                            header_frame.total_margin().expand_rect(header_rect);
-
-                        // Show node's header
-                        let header_ui = &mut ui.child_ui_with_id_source(
-                            header_frame_rect,
-                            Layout::top_down(Align::Center),
-                            node_id,
-                        );
-
-                        header_frame.show(header_ui, |ui: &mut Ui| {
-                            ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
-                                if collapsible {
-                                    let (_, r) = ui.allocate_exact_size(
-                                        vec2(
-                                            node_style.spacing.icon_width,
-                                            node_style.spacing.icon_width,
-                                        ),
-                                        Sense::click(),
-                                    );
-                                    paint_default_icon(ui, openness, &r);
-
-                                    if r.clicked_by(PointerButton::Primary) {
-                                        // Toggle node's openness.
-                                        self.open_node(node_idx, !open);
-                                    }
-                                }
-
-                                ui.allocate_exact_size(header_drag_space, Sense::hover());
-
-                                viewer.show_header(
-                                    node_idx,
-                                    &inputs,
-                                    &outputs,
-                                    ui,
-                                    snarl_state.scale(),
-                                    self,
-                                );
-
-                                header_rect.max = ui.min_rect().max;
-                            });
-
-                            header_frame_rect =
-                                header_frame.total_margin().expand_rect(header_rect);
-
-                            ui.advance_cursor_after_rect(Rect::from_min_max(
-                                header_rect.min,
-                                pos2(
-                                    f32::max(header_rect.max.x, node_rect.max.x),
-                                    header_rect.min.y,
-                                ),
-                            ));
-                        });
-                        if !self.nodes.contains(node_idx) {
-                            node_state.clear(ui.ctx());
-                            // If removed
-                            return;
-                        }
-
-                        let min_pin_y = header_rect.center().y;
-
-                        let input_x =
-                            header_rect.left() + header_frame.total_margin().left + pin_size * 0.5;
-
-                        let output_x = f32::max(header_rect.right(), node_rect.right())
-                            - header_frame.total_margin().right
-                            - pin_size * 0.5;
-
-                        if true {
-                            if (openness < 1.0 && open) || (openness > 0.0 && !open) {
-                                ui.ctx().request_repaint();
-                            }
-
-                            // Show input pins.
-
-                            // Inputs are placed under the header and must not go outside of the header frame.
-
-                            let pins_rect = Rect::from_min_max(
-                                pos2(
-                                    header_rect.min.x,
-                                    header_frame_rect.max.y
-                                        + node_style.spacing.item_spacing.y
-                                        + (node_frame_rect.height()) * (openness - 1.0),
-                                ),
-                                pos2(f32::max(node_rect.max.x, header_rect.max.x), f32::INFINITY),
-                            );
-
-                            let pins_clip_rect = Rect::from_min_max(
-                                pos2(header_rect.min.x, header_frame_rect.max.y),
-                                pos2(f32::max(node_rect.max.x, header_rect.max.x), f32::INFINITY),
-                            );
-
-                            let inputs_ui = &mut ui.child_ui_with_id_source(
-                                pins_rect,
-                                Layout::top_down(Align::Center),
-                                (node_id, "inputs"),
-                            );
-
-                            inputs_ui.set_clip_rect(pins_clip_rect.intersect(viewport));
-
-                            // Input pins on the left.
-                            let r = inputs_ui.with_layout(Layout::top_down(Align::Min), |ui| {
-                                // let r = Grid::new((node_id, "inputs")).min_col_width(0.0).show(ui, |ui| {
-                                for in_pin in inputs {
-                                    // Show input pin.
-                                    ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
-                                        // Allocate space for pin shape.
-                                        let (pin_id, _) =
-                                            ui.allocate_space(vec2(pin_size, pin_size));
-
-                                        let y0 = ui.cursor().min.y;
-
-                                        // Show input content
-                                        let pin_info = viewer.show_input(
-                                            &in_pin,
-                                            ui,
-                                            snarl_state.scale(),
-                                            self,
-                                        );
-                                        if !self.nodes.contains(node_idx) {
-                                            // If removed
-                                            return;
-                                        }
-
-                                        let y1 = ui.min_rect().max.y;
-
-                                        // ui.end_row();
-
-                                        // Centered vertically.
-                                        let y = min_pin_y.max((y0 + y1) * 0.5);
-
-                                        let pin_pos = pos2(input_x, y);
-
-                                        input_positions.insert(in_pin.id, pin_pos);
-                                        input_colors.insert(in_pin.id, pin_info.fill);
-
-                                        // Interact with pin shape.
-                                        let r = ui.interact(
-                                            Rect::from_center_size(
-                                                pin_pos,
-                                                vec2(pin_size, pin_size),
-                                            ),
-                                            pin_id,
-                                            Sense::click_and_drag(),
-                                        );
-
-                                        if r.clicked_by(PointerButton::Secondary) {
-                                            if snarl_state.has_new_wires() {
-                                                snarl_state.remove_new_wire_in(in_pin.id);
-                                            } else {
-                                                viewer.drop_inputs(&in_pin, self);
-                                            }
-                                        }
-                                        if r.drag_started_by(PointerButton::Primary) {
-                                            if input.modifiers.command {
-                                                snarl_state.start_new_wires_out(&in_pin.remotes);
-                                                if !input.modifiers.shift {
-                                                    self.drop_inputs(in_pin.id);
-                                                }
-                                            } else {
-                                                snarl_state.start_new_wire_in(in_pin.id);
-                                            }
-                                        }
-                                        if r.drag_released() {
-                                            drag_released = true;
-                                        }
-
-                                        let mut pin_size = pin_size;
-
-                                        match input.hover_pos {
-                                            Some(hover_pos) if r.rect.contains(hover_pos) => {
-                                                if input.modifiers.shift {
-                                                    snarl_state.add_new_wire_in(in_pin.id);
-                                                } else if input.secondary_pressed {
-                                                    snarl_state.remove_new_wire_in(in_pin.id);
-                                                }
-                                                pin_hovered = Some(AnyPin::In(in_pin.id));
-                                                pin_size *= 1.2;
-                                            }
-                                            _ => {}
-                                        }
-
-                                        draw_pin(ui.painter(), pin_info, pin_pos, pin_size);
-                                    });
-                                }
-                            });
-                            let inputs_rect = r.response.rect;
-
-                            if !self.nodes.contains(node_idx) {
-                                node_state.clear(ui.ctx());
-                                // If removed
-                                return;
-                            }
-
-                            // Show output pins.
-
-                            // Outputs are placed under the header and must not go outside of the header frame.
-
-                            let outputs_ui = &mut ui.child_ui_with_id_source(
-                                pins_rect,
-                                Layout::top_down(Align::Center),
-                                (node_id, "outputs"),
-                            );
-
-                            outputs_ui.set_clip_rect(pins_clip_rect.intersect(viewport));
-
-                            // Output pins on the right.
-                            let r = outputs_ui.with_layout(Layout::top_down(Align::Max), |ui| {
-                                // let r = Grid::new((node_id, "outputs")).min_col_width(0.0).show(ui, |ui| {
-
-                                for out_pin in outputs {
-                                    // Show output pin.
-                                    ui.with_layout(Layout::right_to_left(Align::Min), |ui| {
-                                        // Allocate space for pin shape.
-
-                                        let (pin_id, _) =
-                                            ui.allocate_space(vec2(pin_size, pin_size));
-
-                                        let y0 = ui.cursor().min.y;
-
-                                        // Show output content
-                                        let pin_info = viewer.show_output(
-                                            &out_pin,
-                                            ui,
-                                            snarl_state.scale(),
-                                            self,
-                                        );
-                                        if !self.nodes.contains(node_idx) {
-                                            // If removed
-                                            return;
-                                        }
-
-                                        let y1 = ui.min_rect().max.y;
-
-                                        // ui.end_row();
-
-                                        // Centered vertically.
-                                        let y = min_pin_y.max((y0 + y1) * 0.5);
-
-                                        let pin_pos = pos2(output_x, y);
-
-                                        output_positions.insert(out_pin.id, pin_pos);
-                                        output_colors.insert(out_pin.id, pin_info.fill);
-
-                                        let r = ui.interact(
-                                            Rect::from_center_size(
-                                                pin_pos,
-                                                vec2(pin_size, pin_size),
-                                            ),
-                                            pin_id,
-                                            Sense::click_and_drag(),
-                                        );
-
-                                        if r.clicked_by(PointerButton::Secondary) {
-                                            if snarl_state.has_new_wires() {
-                                                snarl_state.remove_new_wire_out(out_pin.id);
-                                            } else {
-                                                viewer.drop_outputs(&out_pin, self);
-                                            }
-                                        }
-                                        if r.drag_started_by(PointerButton::Primary) {
-                                            if input.modifiers.command {
-                                                snarl_state.start_new_wires_in(&out_pin.remotes);
-
-                                                if !input.modifiers.shift {
-                                                    self.drop_outputs(out_pin.id);
-                                                }
-                                            } else {
-                                                snarl_state.start_new_wire_out(out_pin.id);
-                                            }
-                                        }
-                                        if r.drag_released() {
-                                            drag_released = true;
-                                        }
-
-                                        let mut pin_size = pin_size;
-                                        match input.hover_pos {
-                                            Some(hover_pos) if r.rect.contains(hover_pos) => {
-                                                if input.modifiers.shift {
-                                                    snarl_state.add_new_wire_out(out_pin.id);
-                                                } else if input.secondary_pressed {
-                                                    snarl_state.remove_new_wire_out(out_pin.id);
-                                                }
-                                                pin_hovered = Some(AnyPin::Out(out_pin.id));
-                                                pin_size *= 1.2;
-                                            }
-                                            _ => {}
-                                        }
-                                        draw_pin(ui.painter(), pin_info, pin_pos, pin_size);
-                                    });
-                                }
-                            });
-                            let outputs_rect = r.response.rect;
-
-                            if !self.nodes.contains(node_idx) {
-                                node_state.clear(ui.ctx());
-                                // If removed
-                                return;
-                            }
-
-                            ui.expand_to_include_rect(header_rect);
-                            ui.expand_to_include_rect(inputs_rect.intersect(pins_clip_rect));
-                            ui.expand_to_include_rect(outputs_rect.intersect(pins_clip_rect));
-
-                            let inputs_size = inputs_rect.size();
-                            let outputs_size = outputs_rect.size();
-                            let header_size = header_rect.size();
-
-                            node_state.set_size(vec2(
-                                f32::max(
-                                    header_size.x,
-                                    inputs_size.x
-                                        + outputs_size.x
-                                        + node_style.spacing.item_spacing.x,
-                                ),
-                                header_size.y
-                                    + header_frame.total_margin().bottom
-                                    + node_style.spacing.item_spacing.y
-                                    + f32::max(inputs_size.y, outputs_size.y),
-                            ));
-
-                            // ui.painter()
-                            //     .debug_rect(header_frame_rect, Color32::GREEN, "header");
-                            // ui.painter()
-                            //     .debug_rect(pins_clip_rect, Color32::RED, "pins_clip");
-                        } else {
-                            for in_pin in inputs {
-                                let pin_pos = pos2(input_x, min_pin_y);
-                                input_positions.insert(in_pin.id, pin_pos);
-                                input_colors.insert(
-                                    in_pin.id,
-                                    viewer.input_color(&in_pin, &node_style, self),
-                                );
-
-                                if !self.nodes.contains(node_idx) {
-                                    node_state.clear(ui.ctx());
-                                    // If removed
-                                    return;
-                                }
-                            }
-                            for out_pin in outputs {
-                                let pin_pos = pos2(output_x, min_pin_y);
-                                output_positions.insert(out_pin.id, pin_pos);
-                                output_colors.insert(
-                                    out_pin.id,
-                                    viewer.output_color(&out_pin, &node_style, self),
-                                );
-
-                                if !self.nodes.contains(node_idx) {
-                                    node_state.clear(ui.ctx());
-                                    // If removed
-                                    return;
-                                }
-                            }
-                        }
-                    });
-
-                    node_state.store(ui.ctx());
-                    ui.ctx().request_repaint();
-                };
-
                 for node_idx in draw_order {
-                    show_node(node_idx);
-                }
+                    // show_node(node_idx);
+                    let response = self.draw_node(
+                        ui,
+                        node_idx,
+                        viewer,
+                        &mut snarl_state,
+                        style,
+                        &viewport,
+                        snarl_id,
+                        &node_style,
+                        &node_frame,
+                        &header_frame,
+                        &mut input_positions,
+                        &mut input_colors,
+                        &input,
+                        &mut output_positions,
+                        &mut output_colors,
+                    );
+                    if let Some(v) = response.node_idx_to_top{
+                        node_idx_to_top = Some(v);
+                    }
+                    if let Some(v) = response.node_moved{
+                        node_moved = Some(v);
+                    }
+                    if let Some(v) = response.pin_hovered{
+                        pin_hovered = Some(v);
+                    }
+                    drag_released |= response.drag_released;
+                }   
 
                 let mut hovered_wire = None;
 
@@ -846,5 +423,451 @@ impl<T> Snarl<T> {
                 self.draw_order.push(node_idx);
             }
         }
+    }
+
+    #[inline(always)]
+    fn draw_node<V>(
+        &mut self,
+        ui: &mut Ui,
+        node_idx: usize,
+        viewer: &mut V,
+        snarl_state: &mut SnarlState,
+        style: &SnarlStyle,
+        viewport: &Rect,
+        snarl_id: Id,
+        node_style: &Style,
+        node_frame: &Frame,
+        header_frame: &Frame,
+        input_positions: &mut HashMap<InPinId, Pos2>,
+        input_colors: &mut HashMap<InPinId, Color32>,
+        input: &Input,
+        output_positions: &mut HashMap<OutPinId, Pos2>,
+        output_colors: &mut HashMap<OutPinId, Color32>,
+    ) -> DrawNodeResponse
+    where
+        V: SnarlViewer<T>,
+    {
+        let Node {
+            pos,
+            open,
+            ref value,
+        } = self.nodes[node_idx];
+
+        let mut response = DrawNodeResponse {
+            node_idx_to_top: None,
+            node_moved: None,
+            drag_released: false,
+            pin_hovered: None,
+        };
+
+        // Collect pins
+        let inputs_count = viewer.inputs(value);
+        let outputs_count = viewer.outputs(value);
+
+        let node_pos = snarl_state.graph_pos_to_screen(pos, *viewport);
+
+        // Generate persistent id for the node.
+        let node_id = snarl_id.with(("snarl-node", node_idx));
+
+        let openness = ui.ctx().animate_bool(node_id, open);
+
+        let mut node_state = NodeState::load(ui.ctx(), node_id, &node_style.spacing);
+
+        let node_rect = node_state.node_rect(node_pos);
+
+        let pin_size = style
+            .pin_size
+            .unwrap_or(node_style.spacing.interact_size.y * 0.5);
+
+        let header_drag_space = style
+            .header_drag_space
+            .unwrap_or_else(|| vec2(node_style.spacing.icon_width, node_style.spacing.icon_width));
+
+        // let header_rect = node_state.header_rect(&node_style.spacing, node_pos);
+        // let pins_rect =
+        //     node_state.pins_rect(&header_frame, &node_style.spacing, openness, node_pos);
+
+        // Interact with node frame.
+        let r = ui.interact(node_rect, node_id, Sense::click_and_drag());
+
+        if r.dragged_by(PointerButton::Primary) {
+            response.node_moved = Some((node_idx, snarl_state.screen_vec_to_graph(r.drag_delta())));
+        }
+        if r.clicked() || r.dragged() {
+            response.node_idx_to_top = Some(node_idx);
+        }
+
+        let inputs = (0..inputs_count)
+            .map(|idx| {
+                InPin::new(
+                    self,
+                    InPinId {
+                        node: node_idx,
+                        input: idx,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let outputs = (0..outputs_count)
+            .map(|idx| {
+                OutPin::new(
+                    self,
+                    OutPinId {
+                        node: node_idx,
+                        output: idx,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        r.context_menu(|ui| {
+            viewer.node_menu(node_idx, &inputs, &outputs, ui, snarl_state.scale(), self);
+        });
+
+        if !self.nodes.contains(node_idx) {
+            node_state.clear(ui.ctx());
+            // If removed
+            return response;
+        }
+
+        // Rect for node + frame margin.
+        let node_frame_rect = node_frame.total_margin().expand_rect(node_rect);
+
+        let node_ui = &mut ui.child_ui_with_id_source(
+            node_frame_rect,
+            Layout::top_down(Align::Center),
+            node_id,
+        );
+        node_ui.set_style(node_style.clone());
+
+        node_frame.show(node_ui, |ui| {
+            // Render header frame.
+            let mut header_rect = node_rect;
+
+            let mut header_frame_rect = header_frame.total_margin().expand_rect(header_rect);
+
+            // Show node's header
+            let header_ui = &mut ui.child_ui_with_id_source(
+                header_frame_rect,
+                Layout::top_down(Align::Center),
+                node_id,
+            );
+
+            header_frame.show(header_ui, |ui: &mut Ui| {
+                ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                    if style.collapsible {
+                        let (_, r) = ui.allocate_exact_size(
+                            vec2(node_style.spacing.icon_width, node_style.spacing.icon_width),
+                            Sense::click(),
+                        );
+                        paint_default_icon(ui, openness, &r);
+
+                        if r.clicked_by(PointerButton::Primary) {
+                            // Toggle node's openness.
+                            self.open_node(node_idx, !open);
+                        }
+                    }
+
+                    ui.allocate_exact_size(header_drag_space, Sense::hover());
+
+                    viewer.show_header(node_idx, &inputs, &outputs, ui, snarl_state.scale(), self);
+
+                    header_rect.max = ui.min_rect().max;
+                });
+
+                header_frame_rect = header_frame.total_margin().expand_rect(header_rect);
+
+                ui.advance_cursor_after_rect(Rect::from_min_max(
+                    header_rect.min,
+                    pos2(
+                        f32::max(header_rect.max.x, node_rect.max.x),
+                        header_rect.min.y,
+                    ),
+                ));
+            });
+            if !self.nodes.contains(node_idx) {
+                node_state.clear(ui.ctx());
+                // If removed
+                return;
+            }
+
+            let min_pin_y = header_rect.center().y;
+
+            let input_x = header_rect.left() + header_frame.total_margin().left + pin_size * 0.5;
+
+            let output_x = f32::max(header_rect.right(), node_rect.right())
+                - header_frame.total_margin().right
+                - pin_size * 0.5;
+
+            if true {
+                if (openness < 1.0 && open) || (openness > 0.0 && !open) {
+                    ui.ctx().request_repaint();
+                }
+
+                // Show input pins.
+
+                // Inputs are placed under the header and must not go outside of the header frame.
+
+                let pins_rect = Rect::from_min_max(
+                    pos2(
+                        header_rect.min.x,
+                        header_frame_rect.max.y
+                            + node_style.spacing.item_spacing.y
+                            + (node_frame_rect.height()) * (openness - 1.0),
+                    ),
+                    pos2(f32::max(node_rect.max.x, header_rect.max.x), f32::INFINITY),
+                );
+
+                let pins_clip_rect = Rect::from_min_max(
+                    pos2(header_rect.min.x, header_frame_rect.max.y),
+                    pos2(f32::max(node_rect.max.x, header_rect.max.x), f32::INFINITY),
+                );
+
+                let inputs_ui = &mut ui.child_ui_with_id_source(
+                    pins_rect,
+                    Layout::top_down(Align::Center),
+                    (node_id, "inputs"),
+                );
+
+                inputs_ui.set_clip_rect(pins_clip_rect.intersect(*viewport));
+
+                // Input pins on the left.
+                let r = inputs_ui.with_layout(Layout::top_down(Align::Min), |ui| {
+                    // let r = Grid::new((node_id, "inputs")).min_col_width(0.0).show(ui, |ui| {
+                    for in_pin in inputs {
+                        // Show input pin.
+                        ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                            // Allocate space for pin shape.
+                            let (pin_id, _) = ui.allocate_space(vec2(pin_size, pin_size));
+
+                            let y0 = ui.cursor().min.y;
+
+                            // Show input content
+                            let pin_info =
+                                viewer.show_input(&in_pin, ui, snarl_state.scale(), self);
+                            if !self.nodes.contains(node_idx) {
+                                // If removed
+                                return;
+                            }
+
+                            let y1 = ui.min_rect().max.y;
+
+                            // ui.end_row();
+
+                            // Centered vertically.
+                            let y = min_pin_y.max((y0 + y1) * 0.5);
+
+                            let pin_pos = pos2(input_x, y);
+
+                            input_positions.insert(in_pin.id, pin_pos);
+                            input_colors.insert(in_pin.id, pin_info.fill);
+
+                            // Interact with pin shape.
+                            let r = ui.interact(
+                                Rect::from_center_size(pin_pos, vec2(pin_size, pin_size)),
+                                pin_id,
+                                Sense::click_and_drag(),
+                            );
+
+                            if r.clicked_by(PointerButton::Secondary) {
+                                if snarl_state.has_new_wires() {
+                                    snarl_state.remove_new_wire_in(in_pin.id);
+                                } else {
+                                    viewer.drop_inputs(&in_pin, self);
+                                }
+                            }
+                            if r.drag_started_by(PointerButton::Primary) {
+                                if input.modifiers.command {
+                                    snarl_state.start_new_wires_out(&in_pin.remotes);
+                                    if !input.modifiers.shift {
+                                        self.drop_inputs(in_pin.id);
+                                    }
+                                } else {
+                                    snarl_state.start_new_wire_in(in_pin.id);
+                                }
+                            }
+                            if r.drag_released() {
+                                response.drag_released = true;
+                            }
+
+                            let mut pin_size = pin_size;
+
+                            match input.hover_pos {
+                                Some(hover_pos) if r.rect.contains(hover_pos) => {
+                                    if input.modifiers.shift {
+                                        snarl_state.add_new_wire_in(in_pin.id);
+                                    } else if input.secondary_pressed {
+                                        snarl_state.remove_new_wire_in(in_pin.id);
+                                    }
+                                    response.pin_hovered = Some(AnyPin::In(in_pin.id));
+                                    pin_size *= 1.2;
+                                }
+                                _ => {}
+                            }
+
+                            draw_pin(ui.painter(), pin_info, pin_pos, pin_size);
+                        });
+                    }
+                });
+                let inputs_rect = r.response.rect;
+
+                if !self.nodes.contains(node_idx) {
+                    node_state.clear(ui.ctx());
+                    // If removed
+                    return;
+                }
+
+                // Show output pins.
+
+                // Outputs are placed under the header and must not go outside of the header frame.
+
+                let outputs_ui = &mut ui.child_ui_with_id_source(
+                    pins_rect,
+                    Layout::top_down(Align::Center),
+                    (node_id, "outputs"),
+                );
+
+                outputs_ui.set_clip_rect(pins_clip_rect.intersect(*viewport));
+
+                // Output pins on the right.
+                let r = outputs_ui.with_layout(Layout::top_down(Align::Max), |ui| {
+                    // let r = Grid::new((node_id, "outputs")).min_col_width(0.0).show(ui, |ui| {
+
+                    for out_pin in outputs {
+                        // Show output pin.
+                        ui.with_layout(Layout::right_to_left(Align::Min), |ui| {
+                            // Allocate space for pin shape.
+
+                            let (pin_id, _) = ui.allocate_space(vec2(pin_size, pin_size));
+
+                            let y0 = ui.cursor().min.y;
+
+                            // Show output content
+                            let pin_info =
+                                viewer.show_output(&out_pin, ui, snarl_state.scale(), self);
+                            if !self.nodes.contains(node_idx) {
+                                // If removed
+                                return;
+                            }
+
+                            let y1 = ui.min_rect().max.y;
+
+                            // ui.end_row();
+
+                            // Centered vertically.
+                            let y = min_pin_y.max((y0 + y1) * 0.5);
+
+                            let pin_pos = pos2(output_x, y);
+
+                            output_positions.insert(out_pin.id, pin_pos);
+                            output_colors.insert(out_pin.id, pin_info.fill);
+
+                            let r = ui.interact(
+                                Rect::from_center_size(pin_pos, vec2(pin_size, pin_size)),
+                                pin_id,
+                                Sense::click_and_drag(),
+                            );
+
+                            if r.clicked_by(PointerButton::Secondary) {
+                                if snarl_state.has_new_wires() {
+                                    snarl_state.remove_new_wire_out(out_pin.id);
+                                } else {
+                                    viewer.drop_outputs(&out_pin, self);
+                                }
+                            }
+                            if r.drag_started_by(PointerButton::Primary) {
+                                if input.modifiers.command {
+                                    snarl_state.start_new_wires_in(&out_pin.remotes);
+
+                                    if !input.modifiers.shift {
+                                        self.drop_outputs(out_pin.id);
+                                    }
+                                } else {
+                                    snarl_state.start_new_wire_out(out_pin.id);
+                                }
+                            }
+                            if r.drag_released() {
+                                response.drag_released = true;
+                            }
+
+                            let mut pin_size = pin_size;
+                            match input.hover_pos {
+                                Some(hover_pos) if r.rect.contains(hover_pos) => {
+                                    if input.modifiers.shift {
+                                        snarl_state.add_new_wire_out(out_pin.id);
+                                    } else if input.secondary_pressed {
+                                        snarl_state.remove_new_wire_out(out_pin.id);
+                                    }
+                                    response.pin_hovered = Some(AnyPin::Out(out_pin.id));
+                                    pin_size *= 1.2;
+                                }
+                                _ => {}
+                            }
+                            draw_pin(ui.painter(), pin_info, pin_pos, pin_size);
+                        });
+                    }
+                });
+                let outputs_rect = r.response.rect;
+
+                if !self.nodes.contains(node_idx) {
+                    node_state.clear(ui.ctx());
+                    // If removed
+                    return;
+                }
+
+                ui.expand_to_include_rect(header_rect);
+                ui.expand_to_include_rect(inputs_rect.intersect(pins_clip_rect));
+                ui.expand_to_include_rect(outputs_rect.intersect(pins_clip_rect));
+
+                let inputs_size = inputs_rect.size();
+                let outputs_size = outputs_rect.size();
+                let header_size = header_rect.size();
+
+                node_state.set_size(vec2(
+                    f32::max(
+                        header_size.x,
+                        inputs_size.x + outputs_size.x + node_style.spacing.item_spacing.x,
+                    ),
+                    header_size.y
+                        + header_frame.total_margin().bottom
+                        + node_style.spacing.item_spacing.y
+                        + f32::max(inputs_size.y, outputs_size.y),
+                ));
+
+                // ui.painter()
+                //     .debug_rect(header_frame_rect, Color32::GREEN, "header");
+                // ui.painter()
+                //     .debug_rect(pins_clip_rect, Color32::RED, "pins_clip");
+            } else {
+                for in_pin in inputs {
+                    let pin_pos = pos2(input_x, min_pin_y);
+                    input_positions.insert(in_pin.id, pin_pos);
+                    input_colors.insert(in_pin.id, viewer.input_color(&in_pin, node_style, self));
+
+                    if !self.nodes.contains(node_idx) {
+                        node_state.clear(ui.ctx());
+                        // If removed
+                        return;
+                    }
+                }
+                for out_pin in outputs {
+                    let pin_pos = pos2(output_x, min_pin_y);
+                    output_positions.insert(out_pin.id, pin_pos);
+                    output_colors
+                        .insert(out_pin.id, viewer.output_color(&out_pin, node_style, self));
+
+                    if !self.nodes.contains(node_idx) {
+                        node_state.clear(ui.ctx());
+                        // If removed
+                        return;
+                    }
+                }
+            }
+        });
+
+        node_state.store(ui.ctx());
+        ui.ctx().request_repaint();
+        response
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -209,7 +209,6 @@ impl<T> Snarl<T> {
                         viewer,
                         &mut snarl_state,
                         style,
-                        &viewport,
                         snarl_id,
                         &node_style,
                         &node_frame,
@@ -416,7 +415,6 @@ impl<T> Snarl<T> {
         viewer: &mut V,
         snarl_state: &mut SnarlState,
         style: &SnarlStyle,
-        viewport: &Rect,
         snarl_id: Id,
         node_style: &Style,
         node_frame: &Frame,
@@ -441,11 +439,13 @@ impl<T> Snarl<T> {
             pin_hovered: None,
         };
 
+        let viewport = ui.max_rect();
+
         // Collect pins
         let inputs_count = viewer.inputs(value);
         let outputs_count = viewer.outputs(value);
 
-        let node_pos = snarl_state.graph_pos_to_screen(pos, *viewport);
+        let node_pos = snarl_state.graph_pos_to_screen(pos, viewport);
 
         // Generate persistent id for the node.
         let node_id = snarl_id.with(("snarl-node", node_idx));
@@ -611,7 +611,7 @@ impl<T> Snarl<T> {
                     (node_id, "inputs"),
                 );
 
-                inputs_ui.set_clip_rect(pins_clip_rect.intersect(*viewport));
+                inputs_ui.set_clip_rect(pins_clip_rect.intersect(viewport));
 
                 // Input pins on the left.
                 let r = inputs_ui.with_layout(Layout::top_down(Align::Min), |ui| {
@@ -708,7 +708,7 @@ impl<T> Snarl<T> {
                     (node_id, "outputs"),
                 );
 
-                outputs_ui.set_clip_rect(pins_clip_rect.intersect(*viewport));
+                outputs_ui.set_clip_rect(pins_clip_rect.intersect(viewport));
 
                 // Output pins on the right.
                 let r = outputs_ui.with_layout(Layout::top_down(Align::Max), |ui| {

--- a/src/ui/background_pattern.rs
+++ b/src/ui/background_pattern.rs
@@ -85,6 +85,9 @@ pub enum BackgroundPattern {
     NoPattern,
     /// Linear grid.
     Grid(Grid),
+
+    /// Custom grid
+    Custom(fn(&SnarlStyle, &SnarlState, &Rect, &mut Ui)),
 }
 
 impl Default for BackgroundPattern {
@@ -101,6 +104,7 @@ impl BackgroundPattern {
     pub fn draw(&self, style: &SnarlStyle, snarl_state: &SnarlState, viewport: &Rect, ui: &mut Ui) {
         match self {
             BackgroundPattern::Grid(g) => g.draw(style, snarl_state, viewport, ui),
+            BackgroundPattern::Custom(c) => c(style, snarl_state, viewport, ui),
             BackgroundPattern::NoPattern => {}
         }
     }

--- a/src/ui/background_pattern.rs
+++ b/src/ui/background_pattern.rs
@@ -1,4 +1,4 @@
-use egui::{Rect, Stroke, Ui, Vec2, emath::Rot2, vec2};
+use egui::{emath::Rot2, vec2, Rect, Stroke, Ui, Vec2};
 
 use super::{state::SnarlState, SnarlStyle};
 
@@ -6,6 +6,18 @@ use super::{state::SnarlState, SnarlStyle};
 pub struct Grid {
     spacing: Vec2,
     angle: f32,
+}
+
+const DEFAULT_GRID_SPACING: Vec2 = vec2(5.0, 5.0);
+const DEFAULT_GRID_ANGLE: f32 = 1.0;
+
+impl Default for Grid {
+    fn default() -> Self {
+        Self {
+            spacing: DEFAULT_GRID_SPACING,
+            angle: DEFAULT_GRID_ANGLE,
+        }
+    }
 }
 
 impl Grid {
@@ -70,14 +82,26 @@ impl Grid {
 /// Background pattern show beneath nodes and wires.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BackgroundPattern {
+    NoPattern,
     /// Linear grid.
     Grid(Grid),
 }
 
+impl Default for BackgroundPattern {
+    fn default() -> Self {
+        Self::Grid(Default::default())
+    }
+}
+
 impl BackgroundPattern {
+    pub const fn new() -> Self {
+        Self::Grid(Grid::new(DEFAULT_GRID_SPACING, DEFAULT_GRID_ANGLE))
+    }
+
     pub fn draw(&self, style: &SnarlStyle, snarl_state: &SnarlState, viewport: &Rect, ui: &mut Ui) {
         match self {
             BackgroundPattern::Grid(g) => g.draw(style, snarl_state, viewport, ui),
+            BackgroundPattern::NoPattern => {}
         }
     }
 }

--- a/src/ui/background_pattern.rs
+++ b/src/ui/background_pattern.rs
@@ -3,6 +3,8 @@ use egui::{emath::Rot2, vec2, Rect, Stroke, Ui, Vec2};
 use super::{state::SnarlState, SnarlStyle};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+///Grid background pattern. 
+///Use `SnarlStyle::background_pattern_stroke` for change stroke options
 pub struct Grid {
     spacing: Vec2,
     angle: f32,
@@ -86,8 +88,8 @@ pub enum BackgroundPattern {
     /// Linear grid.
     Grid(Grid),
 
-    /// Custom grid
-    Custom(fn(&SnarlStyle, &SnarlState, &Rect, &mut Ui)),
+    /// Custom pattern
+    Custom(fn(&SnarlStyle, &SnarlState, viewport: &Rect, ui: &mut Ui)),
 }
 
 impl Default for BackgroundPattern {

--- a/src/ui/background_pattern.rs
+++ b/src/ui/background_pattern.rs
@@ -1,0 +1,83 @@
+use egui::{Rect, Stroke, Ui, Vec2, emath::Rot2, vec2};
+
+use super::{state::SnarlState, SnarlStyle};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Grid {
+    spacing: Vec2,
+    angle: f32,
+}
+
+impl Grid {
+    pub const fn new(spacing: Vec2, angle: f32) -> Self {
+        Self { spacing, angle }
+    }
+
+    fn draw(&self, style: &SnarlStyle, snarl_state: &SnarlState, viewport: &Rect, ui: &mut Ui) {
+        let bg_stroke = style
+            .background_pattern_stroke
+            .unwrap_or_else(|| ui.visuals().widgets.noninteractive.bg_stroke);
+
+        let stroke = Stroke::new(
+            bg_stroke.width * snarl_state.scale().max(1.0),
+            bg_stroke.color.gamma_multiply(snarl_state.scale().min(1.0)),
+        );
+
+        let spacing = ui.spacing().icon_width * self.spacing;
+
+        let rot = Rot2::from_angle(self.angle);
+        let rot_inv = rot.inverse();
+
+        let graph_viewport = Rect::from_min_max(
+            snarl_state.screen_pos_to_graph(viewport.min, *viewport),
+            snarl_state.screen_pos_to_graph(viewport.max, *viewport),
+        );
+
+        let pattern_bounds = graph_viewport.rotate_bb(rot_inv);
+
+        let min_x = (pattern_bounds.min.x / spacing.x).ceil();
+        let max_x = (pattern_bounds.max.x / spacing.x).floor();
+
+        for x in 0..=(max_x - min_x) as i64 {
+            let x = (x as f32 + min_x) * spacing.x;
+
+            let top = (rot * vec2(x, pattern_bounds.min.y)).to_pos2();
+            let bottom = (rot * vec2(x, pattern_bounds.max.y)).to_pos2();
+
+            let top = snarl_state.graph_pos_to_screen(top, *viewport);
+            let bottom = snarl_state.graph_pos_to_screen(bottom, *viewport);
+
+            ui.painter().line_segment([top, bottom], stroke);
+        }
+
+        let min_y = (pattern_bounds.min.y / spacing.y).ceil();
+        let max_y = (pattern_bounds.max.y / spacing.y).floor();
+
+        for y in 0..=(max_y - min_y) as i64 {
+            let y = (y as f32 + min_y) * spacing.y;
+
+            let top = (rot * vec2(pattern_bounds.min.x, y)).to_pos2();
+            let bottom = (rot * vec2(pattern_bounds.max.x, y)).to_pos2();
+
+            let top = snarl_state.graph_pos_to_screen(top, *viewport);
+            let bottom = snarl_state.graph_pos_to_screen(bottom, *viewport);
+
+            ui.painter().line_segment([top, bottom], stroke);
+        }
+    }
+}
+
+/// Background pattern show beneath nodes and wires.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BackgroundPattern {
+    /// Linear grid.
+    Grid(Grid),
+}
+
+impl BackgroundPattern {
+    pub fn draw(&self, style: &SnarlStyle, snarl_state: &SnarlState, viewport: &Rect, ui: &mut Ui) {
+        match self {
+            BackgroundPattern::Grid(g) => g.draw(style, snarl_state, viewport, ui),
+        }
+    }
+}

--- a/src/ui/pin.rs
+++ b/src/ui/pin.rs
@@ -92,8 +92,8 @@ pub fn draw_pin(painter: &Painter, pin: PinInfo, pos: Pos2, base_size: f32) {
             painter.circle(pos, size * 0.5, pin.fill, pin.stroke);
         }
         PinShape::Triangle => {
-            const A: Vec2 = vec2(-0.64951905283832895, 0.4875);
-            const B: Vec2 = vec2(0.64951905283832895, 0.4875);
+            const A: Vec2 = vec2(-0.649_519, 0.4875);
+            const B: Vec2 = vec2(0.649_519, 0.4875);
             const C: Vec2 = vec2(0.0, -0.6375);
 
             let points = vec![pos + A * size, pos + B * size, pos + C * size];

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -266,50 +266,38 @@ impl SnarlState {
     }
 
     pub fn add_new_wire_in(&mut self, pin: InPinId) {
-        match self.new_wires {
-            Some(NewWires::In(ref mut pins)) => {
-                if !pins.contains(&pin) {
-                    pins.push(pin);
-                    self.dirty = true;
-                }
+        if let Some(NewWires::In(pins)) = &mut self.new_wires {
+            if !pins.contains(&pin) {
+                pins.push(pin);
+                self.dirty = true;
             }
-            _ => {}
         }
     }
 
     pub fn add_new_wire_out(&mut self, pin: OutPinId) {
-        match self.new_wires {
-            Some(NewWires::Out(ref mut pins)) => {
-                if !pins.contains(&pin) {
-                    pins.push(pin);
-                    self.dirty = true;
-                }
+        if let Some(NewWires::Out(pins)) = &mut self.new_wires {
+            if !pins.contains(&pin) {
+                pins.push(pin);
+                self.dirty = true;
             }
-            _ => {}
         }
     }
 
     pub fn remove_new_wire_in(&mut self, pin: InPinId) {
-        match self.new_wires {
-            Some(NewWires::In(ref mut pins)) => {
-                if let Some(idx) = pins.iter().position(|p| *p == pin) {
-                    pins.swap_remove(idx);
-                    self.dirty = true;
-                }
+        if let Some(NewWires::In(pins)) = &mut self.new_wires {
+            if let Some(idx) = pins.iter().position(|p| *p == pin) {
+                pins.swap_remove(idx);
+                self.dirty = true;
             }
-            _ => {}
         }
     }
 
     pub fn remove_new_wire_out(&mut self, pin: OutPinId) {
-        match self.new_wires {
-            Some(NewWires::Out(ref mut pins)) => {
-                if let Some(idx) = pins.iter().position(|p| *p == pin) {
-                    pins.swap_remove(idx);
-                    self.dirty = true;
-                }
+        if let Some(NewWires::Out(pins)) = &mut self.new_wires {
+            if let Some(idx) = pins.iter().position(|p| *p == pin) {
+                pins.swap_remove(idx);
+                self.dirty = true;
             }
-            _ => {}
         }
     }
 

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -150,7 +150,7 @@ impl SnarlState {
 
             return SnarlState {
                 offset: Vec2::ZERO,
-                scale: scale,
+                scale,
                 target_scale: scale,
                 new_wires: None,
                 id,

--- a/src/ui/wire.rs
+++ b/src/ui/wire.rs
@@ -169,8 +169,6 @@ fn bezier_samples_number(points: &[Pos2; 6], threshold: f32) -> usize {
 }
 
 fn draw_bezier(shapes: &mut Vec<Shape>, points: &[Pos2; 6], mut stroke: Stroke) {
-    assert!(!points.is_empty());
-
     if stroke.width < 1.0 {
         stroke.color = stroke.color.gamma_multiply(stroke.width);
         stroke.width = 1.0;

--- a/src/ui/wire.rs
+++ b/src/ui/wire.rs
@@ -169,7 +169,7 @@ fn bezier_samples_number(points: &[Pos2; 6], threshold: f32) -> usize {
 }
 
 fn draw_bezier(shapes: &mut Vec<Shape>, points: &[Pos2; 6], mut stroke: Stroke) {
-    assert!(points.len() > 0);
+    assert!(!points.is_empty());
 
     if stroke.width < 1.0 {
         stroke.color = stroke.color.gamma_multiply(stroke.width);
@@ -195,6 +195,7 @@ fn draw_bezier(shapes: &mut Vec<Shape>, points: &[Pos2; 6], mut stroke: Stroke) 
     shapes.push(shape);
 }
 
+#[allow(clippy::let_and_return)]
 fn sample_bezier(points: &[Pos2; 6], t: f32) -> Pos2 {
     let [p0, p1, p2, p3, p4, p5] = *points;
 


### PR DESCRIPTION
# What done:
- Cargo clippy fix. Checked and not accepted if is bad
- Background pattern move to own mod. This need for better expanding and split by parts. But this breaking change. In this point i have some questions

## Questions about background pattern api:
- Why ``` SnarlStyle::new ``` is constant but not the ```SnarlStyle::default``` ? ```Default::default``` pattern used in many crates. ```new``` or "builder" use depended on complexity of structure. ""Public fields" pattern is also used if all fields types is public. What pattern you want to used ?
- ```SnarlStyle bg_pattern: Option<BackgroundPattern>``` this field can be ```Option<Box<dyn BackgroundPatternTrait>``` or just 
```rust
pub enum BackgroundPattern{
  #[default]
  None,
  Grid(Grid),
  ... Another patterns
}
``` 
and don`t needed to use ```Option```. Which way will you choose? 