### PR TITLE
Implement #10

### DIFF
--- a/src/ui/pin.rs
+++ b/src/ui/pin.rs
@@ -8,6 +8,16 @@ pub enum AnyPin {
     In(InPinId),
 }
 
+/// In the current context, these are the I/O pins of the 'source' node that the newly
+/// created node's I/O pins will connect to.
+#[derive(Debug)]
+pub enum AnyPins<'a> {
+    /// Output pins.
+    Out(&'a [OutPinId]),
+    /// Input pins
+    In(&'a [InPinId]),
+}
+
 tiny_fn::tiny_fn! {
     /// Custom pin shape drawing function with signature
     /// `Fn(painter: &Painter, rect: Rect, fill: Color32, stroke: Stroke)`

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -150,6 +150,9 @@ pub struct SnarlState {
 
     /// Flag indicating that the graph state is dirty must be saved.
     dirty: bool,
+
+    /// Flag indicating that the link menu is open.
+    is_link_menu_open: bool,
 }
 
 #[derive(Clone)]
@@ -158,6 +161,7 @@ struct SnarlStateData {
     scale: f32,
     target_scale: f32,
     new_wires: Option<NewWires>,
+    is_link_menu_open: bool,
 }
 
 impl SnarlState {
@@ -189,6 +193,7 @@ impl SnarlState {
             scale: data.scale,
             target_scale: data.target_scale,
             new_wires: data.new_wires,
+            is_link_menu_open: data.is_link_menu_open,
             id,
             dirty,
         }
@@ -209,6 +214,7 @@ impl SnarlState {
                 scale,
                 target_scale: scale,
                 new_wires: None,
+                is_link_menu_open: false,
                 id,
                 dirty: true,
             };
@@ -232,6 +238,7 @@ impl SnarlState {
             scale,
             target_scale: scale,
             new_wires: None,
+            is_link_menu_open: false,
             id,
             dirty: true,
         }
@@ -248,6 +255,7 @@ impl SnarlState {
                         scale: self.scale,
                         target_scale: self.target_scale,
                         new_wires: self.new_wires,
+                        is_link_menu_open: self.is_link_menu_open,
                     },
                 )
             });
@@ -373,5 +381,24 @@ impl SnarlState {
     pub fn take_wires(&mut self) -> Option<NewWires> {
         self.dirty |= self.new_wires.is_some();
         self.new_wires.take()
+    }
+
+    pub(crate) fn revert_take_wires(&mut self, wires: NewWires) {
+        self.new_wires = Some(wires);
+    }
+
+    pub(crate) fn open_link_menu(&mut self) {
+        self.is_link_menu_open = true;
+        self.dirty = true;
+    }
+
+    pub(crate) fn close_link_menu(&mut self) {
+        self.new_wires = None;
+        self.is_link_menu_open = false;
+        self.dirty = true;
+    }
+
+    pub(crate) fn is_link_menu_open(&self) -> bool {
+        self.is_link_menu_open
     }
 }

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -2,7 +2,7 @@ use egui::{Color32, Pos2, Style, Ui};
 
 use crate::{InPin, NodeId, OutPin, Snarl};
 
-use super::pin::PinInfo;
+use super::pin::{AnyPins, PinInfo};
 
 /// SnarlViewer is a trait for viewing a Snarl.
 ///
@@ -115,6 +115,25 @@ pub trait SnarlViewer<T> {
     /// This can be used to implement menu for adding new nodes.
     fn graph_menu(&mut self, pos: Pos2, ui: &mut Ui, scale: f32, snarl: &mut Snarl<T>) {
         let _ = (pos, ui, scale, snarl);
+    }
+
+    /// Show context menu for the snarl. This menu is opened when releasing a pin to empty
+    /// space. It can be used to implement menu for adding new node, and directly
+    /// connecting it to the released wire.
+    ///
+    ///
+    fn graph_menu_for_dropped_wire(
+        &mut self,
+        pos: Pos2,
+        ui: &mut Ui,
+        scale: f32,
+        src_pins: AnyPins,
+        snarl: &mut Snarl<T>,
+    ) {
+        let _ = (pos, scale, src_pins, snarl);
+
+        // Default implementation simply doesn't utilize wire drop.
+        ui.close_menu();
     }
 
     /// Show context menu for the snarl.


### PR DESCRIPTION
> Working in progress. Later it'll be squashed into single commit.

Closes #10

- Cancel wire drag on right-click.
- Open context menu on release
  - To reuse existing context menu and keep wire rendering during context menu open, several logics were relocated. This should be tested.
  - Firstly tried to implement using `popup`s, however, it makes code a lot more verbose to immitate context menu. Furthermore, context menu and popups doesn't interfere each other, it results in weird behavior that opening both menus at once.

## Steps

- [x] Open context menu on drop wire
- [x] Cancel wire drag on right click
- [x] Detect link graph menu disposal
- [x] Define trait method (review required for naming)
- [x] Trait method invocation
- [x] (Issue) releasing cursor on node body 'locks' the wire to cursor
- [x] Update demo with new feature.