### PR TITLE
Don't call request_repaint every frame

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2110,7 +2110,6 @@ impl<T> Snarl<T> {
         );
 
         node_state.store(ui.ctx());
-        ui.ctx().request_repaint();
         Some(DrawNodeResponse {
             node_moved,
             node_to_top,


### PR DESCRIPTION
This line
https://github.com/zakarumych/egui-snarl/blob/846cc830f38aa069239fe5836d0731ac241c481a/src/ui.rs#L2113
makes egui repaint everything if the snarl is shown

I tried the demo and my own app with this change and everything seems to work fine.
Of course I may be missing something, in which case please let me know and I will try to update the PR.