### PR TITLE
Upgrade egui/eframe/egui_extras (0.30) and egui-probe (0.7.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["gui", "visualization"]
 serde = ["dep:serde", "egui/serde", "slab/serde"]
 
 [dependencies]
-egui = { version = "0.29" }
+egui = { version = "0.30" }
 slab = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
-egui-probe = { version = "0.6.0", features = ["derive"], optional = true }
+egui-probe = { version = "0.7.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-eframe = { version = "0.29", features = ["serde", "persistence"] }
-egui_extras = { version = "0.29", features = ["all_loaders"] }
+eframe = { version = "0.30", features = ["serde", "persistence"] }
+egui_extras = { version = "0.30", features = ["all_loaders"] }
 syn = { version = "2.0", features = ["extra-traits"] }
 serde_json = { version = "1.0" }
 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -9,10 +9,10 @@ name = "demo"
 path = "../examples/demo.rs"
 
 [dependencies]
-egui = { version = "0.29" }
-egui-probe = { version = "0.6", features = ["derive"] }
-eframe = { version = "0.29", features = ["serde", "persistence"] }
-egui_extras = { version = "0.29", features = ["all_loaders"] }
+egui = { version = "0.30" }
+egui-probe = { version = "0.7", features = ["derive"] }
+eframe = { version = "0.30", features = ["serde", "persistence"] }
+egui_extras = { version = "0.30", features = ["all_loaders"] }
 syn = { version = "2.0", features = ["extra-traits"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -356,7 +356,7 @@ impl SnarlStyle {
     fn get_pin_size(&self, scale: f32, style: &Style) -> f32 {
         self.pin_size
             .zoomed(scale)
-            .unwrap_or_else(|| style.spacing.interact_size.y * 0.6)
+            .unwrap_or(style.spacing.interact_size.y * 0.6)
     }
 
     fn get_pin_fill(&self, style: &Style) -> Color32 {
@@ -372,11 +372,11 @@ impl SnarlStyle {
     }
 
     fn get_pin_shape(&self) -> PinShape {
-        self.pin_shape.unwrap_or(PinShape::Circle).into()
+        self.pin_shape.unwrap_or(PinShape::Circle)
     }
 
     fn get_pin_placement(&self) -> PinPlacement {
-        self.pin_placement.unwrap_or(PinPlacement::default())
+        self.pin_placement.unwrap_or_default()
     }
 
     fn get_wire_width(&self, scale: f32, style: &Style) -> f32 {
@@ -1089,6 +1089,7 @@ impl<T> Snarl<T> {
         });
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_inputs<V>(
         &mut self,
         viewer: &mut V,
@@ -1239,6 +1240,7 @@ impl<T> Snarl<T> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_outputs<V>(
         &mut self,
         viewer: &mut V,
@@ -1388,6 +1390,7 @@ impl<T> Snarl<T> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_body<V>(
         &mut self,
         viewer: &mut V,
@@ -1413,8 +1416,8 @@ impl<T> Snarl<T> {
 
         viewer.show_body(
             node,
-            &inputs,
-            &outputs,
+            inputs,
+            outputs,
             &mut body_ui,
             snarl_state.scale(),
             self,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -208,9 +208,7 @@ impl SnarlStateData {
 
     fn load(cx: &Context, id: Id) -> Option<Self> {
         cx.data(|d| {
-            let Some(small) = d.get_temp::<SnarlStateDataHeader>(id) else {
-                return None;
-            };
+            let small = d.get_temp::<SnarlStateDataHeader>(id)?;
             let new_wires = d.get_temp(id);
             let rect_selection = d.get_temp(id);
 

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -294,6 +294,7 @@ pub trait SnarlViewer<T> {
     /// By default it draws a pin with the shape and style returned by [`SnarlViewer::show_input`].
     ///
     /// If you want to draw the pin yourself, you can override this method.
+    #[allow(clippy::too_many_arguments)]
     fn draw_input_pin(
         &mut self,
         pin: &InPin,
@@ -317,6 +318,7 @@ pub trait SnarlViewer<T> {
     /// By default it draws a pin with the shape and style returned by [`SnarlViewer::show_output`].
     ///
     /// If you want to draw the pin yourself, you can override this method.
+    #[allow(clippy::too_many_arguments)]
     fn draw_output_pin(
         &mut self,
         pin: &OutPin,
@@ -350,9 +352,8 @@ pub trait SnarlViewer<T> {
     ) {
         let _ = snarl;
 
-        match background {
-            Some(background) => background.draw(viewport, snarl_style, style, painter),
-            None => {}
+        if let Some(background) = background {
+            background.draw(viewport, snarl_style, style, painter)
         }
     }
 }


### PR DESCRIPTION
Blocked by: https://github.com/zakarumych/egui-probe/pull/8

This includes the minimum clippy fixes to pass the restriction set:

`#![deny(clippy::correctness, clippy::complexity, clippy::perf, clippy::style)]`

No egui/eframe/egui_extras 0.30 related changes were needed however.


https://github.com/zakarumych/egui-snarl/pull/24 can also probably be closed.