### PR TITLE
Add custom pin drawing functionality to PinInfo struct

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -95,6 +95,8 @@ impl DemoNode {
 struct DemoViewer;
 
 impl SnarlViewer<DemoNode> for DemoViewer {
+    type Drawer = egui_snarl::ui::PinShape;
+
     #[inline]
     fn connect(&mut self, from: &OutPin, to: &InPin, snarl: &mut Snarl<DemoNode>) {
         // Validate connection
@@ -179,7 +181,7 @@ impl SnarlViewer<DemoNode> for DemoViewer {
         ui: &mut Ui,
         scale: f32,
         snarl: &mut Snarl<DemoNode>,
-    ) -> PinInfo {
+    ) -> PinInfo<Self::Drawer> {
         match snarl[pin.id.node] {
             DemoNode::Sink => {
                 assert_eq!(pin.id.input, 0, "Sink node has only one input");
@@ -394,7 +396,7 @@ impl SnarlViewer<DemoNode> for DemoViewer {
         ui: &mut Ui,
         _scale: f32,
         snarl: &mut Snarl<DemoNode>,
-    ) -> PinInfo {
+    ) -> PinInfo<Self::Drawer> {
         match snarl[pin.id.node] {
             DemoNode::Sink => {
                 unreachable!("Sink node has no outputs")

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -26,7 +26,7 @@ use self::{
 
 pub use self::{
     background_pattern::{BackgroundPattern, Grid, Viewport},
-    pin::{AnyPins, PinInfo, PinShape},
+    pin::{AnyPins, CustomPinDrawer, PinInfo, PinShape},
     viewer::SnarlViewer,
     wire::{WireLayer, WireStyle},
 };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -26,7 +26,7 @@ use self::{
 
 pub use self::{
     background_pattern::{BackgroundPattern, Grid, Viewport},
-    pin::{AnyPins, CustomPinDrawer, PinInfo, PinShape},
+    pin::{AnyPins, PinDrawer, PinInfo, PinShape},
     viewer::SnarlViewer,
     wire::{WireLayer, WireStyle},
 };

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -2,13 +2,19 @@ use egui::{Color32, Painter, Pos2, Rect, Style, Ui};
 
 use crate::{InPin, InPinId, NodeId, OutPin, OutPinId, Snarl};
 
-use super::{pin::AnyPins, BackgroundPattern, NodeLayout, PinInfo, SnarlStyle, Viewport};
+use super::{
+    pin::AnyPins, BackgroundPattern, NodeLayout, PinDrawer, PinInfo, SnarlStyle, Viewport,
+};
 
 /// `SnarlViewer` is a trait for viewing a Snarl.
 ///
 /// It can extract necessary data from the nodes and controls their
 /// response to certain events.
 pub trait SnarlViewer<T> {
+    /// The drawer type for the pins.
+    /// If you use the default pin drawer, you can use `PinShape` as the drawer type.
+    type Drawer: PinDrawer;
+
     /// Returns title of the node.
     fn title(&mut self, node: &T) -> String;
 
@@ -76,8 +82,13 @@ pub trait SnarlViewer<T> {
     fn inputs(&mut self, node: &T) -> usize;
 
     /// Renders the node's input.
-    fn show_input(&mut self, pin: &InPin, ui: &mut Ui, scale: f32, snarl: &mut Snarl<T>)
-        -> PinInfo;
+    fn show_input(
+        &mut self,
+        pin: &InPin,
+        ui: &mut Ui,
+        scale: f32,
+        snarl: &mut Snarl<T>,
+    ) -> PinInfo<Self::Drawer>;
 
     /// Returns number of output pins of the node.
     ///
@@ -91,7 +102,7 @@ pub trait SnarlViewer<T> {
         ui: &mut Ui,
         scale: f32,
         snarl: &mut Snarl<T>,
-    ) -> PinInfo;
+    ) -> PinInfo<Self::Drawer>;
 
     /// Checks if node has something to show in body - between input and output pins.
     #[inline]
@@ -298,7 +309,7 @@ pub trait SnarlViewer<T> {
     fn draw_input_pin(
         &mut self,
         pin: &InPin,
-        pin_info: &PinInfo,
+        pin_info: &PinInfo<Self::Drawer>,
         pos: Pos2,
         size: f32,
         snarl_style: &SnarlStyle,
@@ -322,7 +333,7 @@ pub trait SnarlViewer<T> {
     fn draw_output_pin(
         &mut self,
         pin: &OutPin,
-        pin_info: &PinInfo,
+        pin_info: &PinInfo<Self::Drawer>,
         pos: Pos2,
         size: f32,
         snarl_style: &SnarlStyle,


### PR DESCRIPTION
I used it in the previous version.

https://github.com/zakarumych/egui-snarl/commit/71284962e4a25e512b4b82db574e6928b8139bcf

It is not a very good implementation, but we want to use it now, so it is implemented with compatibility in mind.