### PR TITLE
Allow viewer co customize egui style for the individual node UI

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1597,6 +1597,14 @@ impl<T> Snarl<T> {
         let mut new_pins_size = Vec2::ZERO;
 
         let r = node_frame.show(node_ui, |ui| {
+            viewer.node_style(
+                ui,
+                node,
+                &inputs,
+                &outputs,
+                self,
+            );
+
             let min_pin_y = node_state.header_height().mul_add(0.5, node_rect.min.y);
 
             // Input pins' center side by X axis.

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -38,6 +38,18 @@ pub trait SnarlViewer<T> {
         default
     }
 
+    /// Modifies the node's egui style
+    fn node_style(
+        &mut self,
+        ui: &mut Ui,
+        node: NodeId,
+        inputs: &[InPin],
+        outputs: &[OutPin],
+        snarl: &Snarl<T>,
+    ) {
+        let _ = (ui, node, inputs, outputs, snarl);
+    }
+
     /// Returns layout override for the node.
     ///
     /// This method can be used to override the default layout of the node.


### PR DESCRIPTION
This would allow the viewer to tweak ui style of all node elements, instead of tweaking each one individually.

In my app, I use this to lock the node to light or dark mode