### PR TITLE
Wire color and custom pin positions

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -612,8 +612,9 @@ struct DrawBodyResponse {
 
 struct PinResponse {
     pos: Pos2,
-    pin_color: Color32,
+    // pin_color: Color32,
     wire_style: Option<WireStyle>,
+    wire_color: Color32,
 }
 
 impl<T> Snarl<T> {
@@ -808,7 +809,7 @@ impl<T> Snarl<T> {
                     }
                 }
 
-                let color = mix_colors(from_r.pin_color, to_r.pin_color);
+                let color = mix_colors(from_r.wire_color, to_r.wire_color);
 
                 let mut draw_width = wire_width;
                 if hovered_wire == Some(wire) {
@@ -1032,7 +1033,7 @@ impl<T> Snarl<T> {
                             style.get_downscale_wire_frame(),
                             from_pos,
                             to_r.pos,
-                            Stroke::new(wire_width, to_r.pin_color),
+                            Stroke::new(wire_width, to_r.wire_color),
                             to_r.wire_style
                                 .zoomed(snarl_state.scale())
                                 .unwrap_or_else(|| style.get_wire_style(snarl_state.scale())),
@@ -1052,7 +1053,7 @@ impl<T> Snarl<T> {
                             style.get_downscale_wire_frame(),
                             from_r.pos,
                             to_pos,
-                            Stroke::new(wire_width, from_r.pin_color),
+                            Stroke::new(wire_width, from_r.wire_color),
                             from_r
                                 .wire_style
                                 .zoomed(snarl_state.scale())
@@ -1154,8 +1155,8 @@ impl<T> Snarl<T> {
 
                 // ui.end_row();
 
-                // Centered vertically.
-                let y = min_pin_y.max((y0 + y1) * 0.5);
+                // Centered vertically by default.
+                let y = pin_info.position.unwrap_or(min_pin_y.max((y0 + y1) * 0.5));
 
                 let pin_pos = pos2(input_x, y);
 
@@ -1233,8 +1234,9 @@ impl<T> Snarl<T> {
                     in_pin.id,
                     PinResponse {
                         pos: r.rect.center(),
-                        pin_color,
+                        // pin_color,
                         wire_style: pin_info.wire_style,
+                        wire_color: pin_info.wire_color.unwrap_or(pin_color),
                     },
                 );
             });
@@ -1306,8 +1308,8 @@ impl<T> Snarl<T> {
 
                 // ui.end_row();
 
-                // Centered vertically.
-                let y = min_pin_y.max((y0 + y1) * 0.5);
+                // Centered vertically by default.
+                let y = pin_info.position.unwrap_or(min_pin_y.max((y0 + y1) * 0.5));
 
                 let pin_pos = pos2(output_x, y);
 
@@ -1384,8 +1386,9 @@ impl<T> Snarl<T> {
                     out_pin.id,
                     PinResponse {
                         pos: r.rect.center(),
-                        pin_color,
+                        // pin_color,
                         wire_style: pin_info.wire_style,
+                        wire_color: pin_info.wire_color.unwrap_or(pin_color),
                     },
                 );
             });

--- a/src/ui/pin.rs
+++ b/src/ui/pin.rs
@@ -1,4 +1,4 @@
-use egui::{epaint::PathShape, vec2, Color32, Painter, Pos2, Shape, Stroke, Style, Vec2};
+use egui::{epaint::PathShape, vec2, Align, Color32, Painter, Pos2, Shape, Stroke, Style, Vec2};
 
 use crate::{InPinId, OutPinId};
 
@@ -59,6 +59,13 @@ pub struct PinInfo {
 
     /// Style of the wire connected to the pin.
     pub wire_style: Option<WireStyle>,
+
+    /// Color of the wire connected to the pin.
+    /// Default is the same as the fill color.
+    pub wire_color: Option<Color32>,
+
+    /// Custom vertical position of a pin
+    pub position: Option<f32>
 }
 
 impl PinInfo {


### PR DESCRIPTION
I needed this to properly render input pins when I added a bunch of decorations to the input pin UI, which caused visual pin to be misaligned with the inputs and label.

### Before
![image](https://github.com/user-attachments/assets/e50ad326-fa2d-4536-b034-8a4f71ac41e7)

### After
![image](https://github.com/user-attachments/assets/b3ea5875-e3bc-4943-8e8b-e554687fbc41)

---

I'm not sure this is the best approach for general use cases. I needed a precise control over the positioning of the pin, but more generally, it would be nice to have some simple options. For example, making the pin be drawn on the top or on the bottom of the pin ui, to assist with cases with large inline inputs.

As an example, in this node, the inline input is very large, and the pin is in the inconvenient position.
![image](https://github.com/user-attachments/assets/08de63b3-693c-497d-957b-c6b6836b847b)

Changes in my PR allow positioning the pin manually to the top of the input, but it still requires doing some math and knowing the exact size of the pin.

---

Wire color issue was mentioned here #51.