### PR TITLE
Merge multiple open PRs: Wire widget, config system, left-click disconnect, and ESC key deselect

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install MSRV
-      run: rustup install 1.85
+      run: rustup install 1.88
     - name: Test on MSRV
-      run: cargo +1.85 test
+      run: cargo +1.88 test

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Effects::disconnect_all(node_id)` for deferred disconnection of all node wires.
 - `SnarlViewer::node_moved` callback invoked when a node is dragged to a new position.
 - `SnarlConfig::single_select` option to limit selection to a single node at a time.
-- `SnarlConfig::grid_snap` option for snapping node positions to a grid.
+- `SnapGrid` and `SnapGridType` types for configurable snap grids with quad and hex (pointy/flat) variants.
+- `SnarlConfig::grid_snap` now accepts `Option<SnapGrid>` for full grid configuration including type and visibility.
 - `SnarlViewer::show_header_buttons` method for adding buttons/flags to node headers (Houdini-style).
 - `SnarlViewer::draw_foreground` method for drawing comments, annotations, and overlays on top of the graph.
 - `SnarlViewer::wire_waypoints` method for specifying custom wire routing waypoints.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Effects::disconnect_all(node_id)` for deferred disconnection of all node wires.
 - `SnarlViewer::node_moved` callback invoked when a node is dragged to a new position.
 - `SnarlConfig::single_select` option to limit selection to a single node at a time.
+- `SnarlConfig::grid_snap` option for snapping node positions to a grid.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SnarlConfig::grid_snap` option for snapping node positions to a grid.
 - `SnarlViewer::show_header_buttons` method for adding buttons/flags to node headers (Houdini-style).
 - `SnarlViewer::draw_foreground` method for drawing comments, annotations, and overlays on top of the graph.
+- `SnarlViewer::wire_waypoints` method for specifying custom wire routing waypoints.
+- `SnarlViewer::compute_layout` and `apply_layout` methods for implementing automatic node layout algorithms.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SnarlViewer::current_transform` method to receive and possibly modify the current transform of the snarl's UI layer.
 - `SnarlStyle::pin_hover_scale` option to control or disable pin hover scaling effect. Set to `1.0` to disable hover effect.
+- `Snarl::disconnect_all(node_id)` method to remove all connections to and from a node.
+- `Effects::disconnect_all(node_id)` for deferred disconnection of all node wires.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Collapsed nodes now shrink their width to match the header width instead of retaining full content width.
 - Snarl is now scaled using egui's layer scaling mechanism.
   Removes layout twitching when zooming in and out.
   Simplifies interface of `SnarlViewer`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SnarlConfig::single_select` option to limit selection to a single node at a time.
 - `SnarlConfig::grid_snap` option for snapping node positions to a grid.
 - `SnarlViewer::show_header_buttons` method for adding buttons/flags to node headers (Houdini-style).
+- `SnarlViewer::draw_foreground` method for drawing comments, annotations, and overlays on top of the graph.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Snarl::disconnect_all(node_id)` method to remove all connections to and from a node.
 - `Effects::disconnect_all(node_id)` for deferred disconnection of all node wires.
 - `SnarlViewer::node_moved` callback invoked when a node is dragged to a new position.
+- `SnarlConfig::single_select` option to limit selection to a single node at a time.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `SnarlViewer::current_transform` method to receive and possibly modify the current transform of the snarl's UI layer.
+- `SnarlStyle::pin_hover_scale` option to control or disable pin hover scaling effect. Set to `1.0` to disable hover effect.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,9 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SnarlViewer::node_moved` callback invoked when a node is dragged to a new position.
 - `SnarlConfig::single_select` option to limit selection to a single node at a time.
 - `SnarlConfig::grid_snap` option for snapping node positions to a grid.
+- `SnarlViewer::show_header_buttons` method for adding buttons/flags to node headers (Houdini-style).
 
 ### Changed
 
+- `SnarlViewer::show_header` now uses horizontal layout with title on left and header buttons on right.
 - Collapsed nodes now shrink their width to match the header width instead of retaining full content width.
 - Snarl is now scaled using egui's layer scaling mechanism.
   Removes layout twitching when zooming in and out.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snarl is now scaled using egui's layer scaling mechanism.
   Removes layout twitching when zooming in and out.
   Simplifies interface of `SnarlViewer`.
+- Renamed `Snarl::get_node` to `node`, `get_node_mut` to `node_mut`, `get_node_info` to `node_info`, and `get_node_info_mut` to `node_info_mut` per Rust API guidelines.
+  The old names are deprecated but still available for backwards compatibility.
 
 ## [0.7.1] - 19.02.2025
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SnarlStyle::pin_hover_scale` option to control or disable pin hover scaling effect. Set to `1.0` to disable hover effect.
 - `Snarl::disconnect_all(node_id)` method to remove all connections to and from a node.
 - `Effects::disconnect_all(node_id)` for deferred disconnection of all node wires.
+- `SnarlViewer::node_moved` callback invoked when a node is dragged to a new position.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ syn = { version = "2" }
 serde = { version = "1" }
 serde_json = { version = "1" }
 
-egui-probe = { version = "0.8.0", git = "https://github.com/zakarumych/egui-probe" }
+egui-probe = { version = "0.8.0", git = "https://github.com/zakarumych/egui-probe", branch = "main" }
 egui-scale = { version = "0.1.0" }
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["demo"]
 resolver = "3"
 
 [workspace.package]
-rust-version = "1.85"
+rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/egui-snarl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1" }
 serde_json = { version = "1" }
 
 egui-probe = { version = "0.10" }
+facet = { version = "0.31" }
 egui-scale = { version = "0.3" }
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
@@ -38,6 +39,7 @@ categories = ["gui", "visualization"]
 
 [features]
 serde = ["dep:serde", "egui/serde", "slab/serde"]
+facet = ["dep:facet"]
 
 [dependencies]
 egui.workspace = true
@@ -46,6 +48,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 smallvec = { version = "1.15", features = ["const_new"] }
 
 egui-probe = { workspace = true, features = ["derive"], optional = true }
+facet = { workspace = true, optional = true }
 egui-scale.workspace = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ documentation = "https://docs.rs/egui-snarl"
 repository = "https://github.com/zakarumych/egui-snarl"
 
 [workspace.dependencies]
-egui = { version = "0.32" }
-eframe = { version = "0.32" }
-egui_extras = { version = "0.32" }
+egui = { version = "0.33" }
+eframe = { version = "0.33" }
+egui_extras = { version = "0.33" }
 syn = { version = "2" }
 serde = { version = "1" }
 serde_json = { version = "1" }
 
-egui-probe = { version = "0.9" }
-egui-scale = { version = "0.2" }
+egui-probe = { version = "0.10" }
+egui-scale = { version = "0.3" }
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ impl<T> Default for Snarl<T> {
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
+#[cfg_attr(feature = "facet", derive(facet::Facet))]
 pub struct NodeId(pub usize);
 
 /// Node of the graph.
@@ -62,6 +63,7 @@ pub struct Node<T> {
 /// Cosists of node id and pin index.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "facet", derive(facet::Facet))]
 pub struct OutPinId {
     /// Node id.
     pub node: NodeId,
@@ -73,6 +75,7 @@ pub struct OutPinId {
 /// Input pin identifier. Cosists of node id and pin index.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "facet", derive(facet::Facet))]
 pub struct InPinId {
     /// Node id.
     pub node: NodeId,
@@ -408,20 +411,29 @@ impl<T> Snarl<T> {
     }
 
     /// Deprecated: Use [`node_mut`](Self::node_mut) instead.
-    #[deprecated(since = "0.8.0", note = "renamed to `node_mut` per Rust API guidelines")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "renamed to `node_mut` per Rust API guidelines"
+    )]
     pub fn get_node_mut(&mut self, idx: NodeId) -> Option<&mut T> {
         self.node_mut(idx)
     }
 
     /// Deprecated: Use [`node_info`](Self::node_info) instead.
-    #[deprecated(since = "0.8.0", note = "renamed to `node_info` per Rust API guidelines")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "renamed to `node_info` per Rust API guidelines"
+    )]
     #[must_use]
     pub fn get_node_info(&self, idx: NodeId) -> Option<&Node<T>> {
         self.node_info(idx)
     }
 
     /// Deprecated: Use [`node_info_mut`](Self::node_info_mut) instead.
-    #[deprecated(since = "0.8.0", note = "renamed to `node_info_mut` per Rust API guidelines")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "renamed to `node_info_mut` per Rust API guidelines"
+    )]
     pub fn get_node_info_mut(&mut self, idx: NodeId) -> Option<&mut Node<T>> {
         self.node_info_mut(idx)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,18 @@ impl<T> Snarl<T> {
         self.wires.drop_outputs(pin)
     }
 
+    /// Removes all connections to and from the node.
+    /// Returns number of removed connections.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node does not exist.
+    #[track_caller]
+    pub fn disconnect_all(&mut self, node: NodeId) -> usize {
+        assert!(self.nodes.contains(node.0));
+        self.wires.drop_node(node)
+    }
+
     /// Returns reference to the node.
     #[must_use]
     pub fn get_node(&self, idx: NodeId) -> Option<&T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,12 +377,12 @@ impl<T> Snarl<T> {
 
     /// Returns reference to the node.
     #[must_use]
-    pub fn get_node(&self, idx: NodeId) -> Option<&T> {
+    pub fn node(&self, idx: NodeId) -> Option<&T> {
         self.nodes.get(idx.0).map(|node| &node.value)
     }
 
     /// Returns mutable reference to the node.
-    pub fn get_node_mut(&mut self, idx: NodeId) -> Option<&mut T> {
+    pub fn node_mut(&mut self, idx: NodeId) -> Option<&mut T> {
         match self.nodes.get_mut(idx.0) {
             Some(node) => Some(&mut node.value),
             None => None,
@@ -391,13 +391,39 @@ impl<T> Snarl<T> {
 
     /// Returns reference to the node data.
     #[must_use]
-    pub fn get_node_info(&self, idx: NodeId) -> Option<&Node<T>> {
+    pub fn node_info(&self, idx: NodeId) -> Option<&Node<T>> {
         self.nodes.get(idx.0)
     }
 
     /// Returns mutable reference to the node data.
-    pub fn get_node_info_mut(&mut self, idx: NodeId) -> Option<&mut Node<T>> {
+    pub fn node_info_mut(&mut self, idx: NodeId) -> Option<&mut Node<T>> {
         self.nodes.get_mut(idx.0)
+    }
+
+    /// Deprecated: Use [`node`](Self::node) instead.
+    #[deprecated(since = "0.8.0", note = "renamed to `node` per Rust API guidelines")]
+    #[must_use]
+    pub fn get_node(&self, idx: NodeId) -> Option<&T> {
+        self.node(idx)
+    }
+
+    /// Deprecated: Use [`node_mut`](Self::node_mut) instead.
+    #[deprecated(since = "0.8.0", note = "renamed to `node_mut` per Rust API guidelines")]
+    pub fn get_node_mut(&mut self, idx: NodeId) -> Option<&mut T> {
+        self.node_mut(idx)
+    }
+
+    /// Deprecated: Use [`node_info`](Self::node_info) instead.
+    #[deprecated(since = "0.8.0", note = "renamed to `node_info` per Rust API guidelines")]
+    #[must_use]
+    pub fn get_node_info(&self, idx: NodeId) -> Option<&Node<T>> {
+        self.node_info(idx)
+    }
+
+    /// Deprecated: Use [`node_info_mut`](Self::node_info_mut) instead.
+    #[deprecated(since = "0.8.0", note = "renamed to `node_info_mut` per Rust API guidelines")]
+    pub fn get_node_info_mut(&mut self, idx: NodeId) -> Option<&mut Node<T>> {
+        self.node_info_mut(idx)
     }
 
     /// Iterates over shared references to each node.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod ui;
 
 use std::ops::{Index, IndexMut};
 
-use egui::{ahash::HashSet, Pos2};
+use egui::{Pos2, ahash::HashSet};
 use slab::Slab;
 
 impl<T> Default for Snarl<T> {
@@ -184,14 +184,14 @@ impl Wires {
         self.wires
             .iter()
             .filter(move |wire| wire.out_pin == out_pin)
-            .map(|wire| (wire.in_pin))
+            .map(|wire| wire.in_pin)
     }
 
     fn wired_outputs(&self, in_pin: InPinId) -> impl Iterator<Item = OutPinId> + '_ {
         self.wires
             .iter()
             .filter(move |wire| wire.in_pin == in_pin)
-            .map(|wire| (wire.out_pin))
+            .map(|wire| wire.out_pin)
     }
 
     fn iter(&self) -> impl Iterator<Item = Wire> + '_ {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1145,7 +1145,7 @@ where
                         ui.interact(snarl_resp.rect, ui.make_persistent_id(wire), Sense::click());
 
                     //Remove hovered wire by second click
-                    hovered_wire_disconnect |= wire_r.clicked_by(PointerButton::Secondary);
+                    hovered_wire_disconnect |= wire_r.clicked_by(PointerButton::Secondary) | wire_r.clicked_by(PointerButton::Primary);
                 }
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1596,16 +1596,31 @@ where
     if let Some((node, delta)) = node_moved {
         if snarl.nodes.contains(node.0) {
             ui.ctx().request_repaint();
+
+            // Helper to snap position to grid if enabled
+            let snap_to_grid = |pos: Pos2| -> Pos2 {
+                if let Some(grid_size) = config.grid_snap {
+                    Pos2::new(
+                        (pos.x / grid_size).round() * grid_size,
+                        (pos.y / grid_size).round() * grid_size,
+                    )
+                } else {
+                    pos
+                }
+            };
+
             if snarl_state.selected_nodes().contains(&node) {
                 for node_id in snarl_state.selected_nodes() {
                     let node_data = &mut snarl.nodes[node_id.0];
                     node_data.pos += delta;
+                    node_data.pos = snap_to_grid(node_data.pos);
                     let new_pos = node_data.pos;
                     viewer.node_moved(*node_id, new_pos, snarl);
                 }
             } else {
                 let node_data = &mut snarl.nodes[node.0];
                 node_data.pos += delta;
+                node_data.pos = snap_to_grid(node_data.pos);
                 let new_pos = node_data.pos;
                 viewer.node_moved(node, new_pos, snarl);
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1056,6 +1056,16 @@ where
         snarl_state.select_many_nodes(true, selection.iter().cloned());
     }
 
+    // Apply automatic layout if requested
+    if viewer.apply_layout(snarl) {
+        let layout = viewer.compute_layout(snarl);
+        for (node_id, new_pos) in layout {
+            if let Some(node) = snarl.nodes.get_mut(node_id.0) {
+                node.pos = new_pos;
+            }
+        }
+    }
+
     let mut to_global = snarl_state.to_global();
 
     let clip_rect = ui.clip_rect();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,7 +34,7 @@ use self::{
 
 pub use self::{
     background_pattern::{BackgroundPattern, Grid},
-    config::{ModifierClick, SnarlConfig},
+    config::{ModifierClick, SnapGrid, SnapGridType, SnarlConfig},
     pin::{AnyPins, PinInfo, PinShape, PinWireInfo, SnarlPin},
     state::get_selected_nodes,
     viewer::SnarlViewer,
@@ -1127,6 +1127,11 @@ where
         snarl,
     );
 
+    // Draw snap grid if visible
+    if let Some(ref grid) = config.grid_snap {
+        grid.draw(&viewport, ui.painter());
+    }
+
     let mut node_moved = None;
     let mut node_to_top = None;
 
@@ -1609,11 +1614,8 @@ where
 
             // Helper to snap position to grid if enabled
             let snap_to_grid = |pos: Pos2| -> Pos2 {
-                if let Some(grid_size) = config.grid_snap {
-                    Pos2::new(
-                        (pos.x / grid_size).round() * grid_size,
-                        (pos.y / grid_size).round() * grid_size,
-                    )
+                if let Some(ref grid) = config.grid_snap {
+                    grid.snap(pos)
                 } else {
                     pos
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2665,6 +2665,7 @@ where
         ui.expand_to_include_rect(header_rect);
         let header_size = header_rect.size();
         node_state.set_header_height(header_size.y);
+        node_state.set_header_width(header_size.x);
 
         node_state.set_size(vec2(
             f32::max(header_size.x, new_pins_size.x),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -586,6 +586,16 @@ pub struct SnarlStyle {
     #[cfg_attr(feature = "egui-probe", egui_probe(skip))]
     pub wire_widget_align: Option<Align2>,
 
+    /// Controls the scale factor for pin hover effect.
+    /// Set to 1.0 to disable the hover effect.
+    /// Defaults to 1.2 (20% larger on hover).
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
+    #[cfg_attr(feature = "egui-probe", egui_probe(range = 1.0..=2.0))]
+    pub pin_hover_scale: Option<f32>,
+
     #[doc(hidden)]
     #[cfg_attr(feature = "egui-probe", egui_probe(skip))]
     #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
@@ -723,6 +733,10 @@ impl SnarlStyle {
     fn get_wire_smoothness(&self) -> f32 {
         self.wire_smoothness.unwrap_or(1.0)
     }
+
+    fn get_pin_hover_scale(&self) -> f32 {
+        self.pin_hover_scale.unwrap_or(1.2)
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -811,6 +825,7 @@ impl SnarlStyle {
             wire_smoothness: None,
             wire_widget_gap: None,
             wire_widget_align: None,
+            pin_hover_scale: None,
 
             _non_exhaustive: (),
         }
@@ -1725,7 +1740,7 @@ where
                     }
                 }
                 pin_hovered = Some(AnyPin::In(in_pin.id));
-                visual_pin_rect = visual_pin_rect.scale_from_center(1.2);
+                visual_pin_rect = visual_pin_rect.scale_from_center(style.get_pin_hover_scale());
             }
 
             let wire_info =
@@ -1890,7 +1905,7 @@ where
                     }
                 }
                 pin_hovered = Some(AnyPin::Out(out_pin.id));
-                visual_pin_rect = visual_pin_rect.scale_from_center(1.2);
+                visual_pin_rect = visual_pin_rect.scale_from_center(style.get_pin_hover_scale());
             }
 
             let wire_info =

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1590,13 +1590,17 @@ where
         if snarl.nodes.contains(node.0) {
             ui.ctx().request_repaint();
             if snarl_state.selected_nodes().contains(&node) {
-                for node in snarl_state.selected_nodes() {
-                    let node = &mut snarl.nodes[node.0];
-                    node.pos += delta;
+                for node_id in snarl_state.selected_nodes() {
+                    let node_data = &mut snarl.nodes[node_id.0];
+                    node_data.pos += delta;
+                    let new_pos = node_data.pos;
+                    viewer.node_moved(*node_id, new_pos, snarl);
                 }
             } else {
-                let node = &mut snarl.nodes[node.0];
-                node.pos += delta;
+                let node_data = &mut snarl.nodes[node.0];
+                node_data.pos += delta;
+                let new_pos = node_data.pos;
+                viewer.node_moved(node, new_pos, snarl);
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -36,7 +36,7 @@ pub use self::{
     background_pattern::{BackgroundPattern, Grid},
     config::{ModifierClick, SnapGrid, SnapGridType, SnarlConfig},
     pin::{AnyPins, PinInfo, PinShape, PinWireInfo, SnarlPin},
-    state::get_selected_nodes,
+    state::selected_nodes,
     viewer::SnarlViewer,
     wire::{WireLayer, WireStyle},
 };
@@ -2126,7 +2126,11 @@ where
             let reset = config.single_select || modifiers.command;
             snarl_state.select_one_node(reset, node);
         } else if modifiers.contains(config.deselect_node.modifiers) {
+            // Cmd+click: deselect
             snarl_state.deselect_one_node(node);
+        } else {
+            // Plain click: select exclusively (deselect all others first)
+            snarl_state.select_one_node(true, node);
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1627,6 +1627,9 @@ where
         }
     }
 
+    // Draw foreground elements (comments, annotations, overlays)
+    viewer.draw_foreground(&viewport, &style, ui.style(), ui.painter(), snarl);
+
     snarl_state.store(snarl, ui.ctx());
 
     snarl_resp

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1653,15 +1653,18 @@ where
                 ));
             }
 
-            let y0 = pin_ui.max_rect().min.y;
-            let y1 = pin_ui.max_rect().max.y;
-
             // Show input content
             let snarl_pin = viewer.show_input(in_pin, pin_ui, snarl);
             if !snarl.nodes.contains(node.0) {
                 // If removed
                 return;
             }
+
+            // Use min_rect after content is shown to get actual content bounds.
+            // This ensures pin is aligned with actual content, not pre-allocated space.
+            let content_rect = pin_ui.min_rect();
+            let y0 = content_rect.min.y;
+            let y1 = content_rect.max.y;
 
             let pin_rect = snarl_pin.pin_rect(
                 input_x,
@@ -1817,15 +1820,18 @@ where
                 ));
             }
 
-            let y0 = pin_ui.max_rect().min.y;
-            let y1 = pin_ui.max_rect().max.y;
-
             // Show output content
             let snarl_pin = viewer.show_output(out_pin, pin_ui, snarl);
             if !snarl.nodes.contains(node.0) {
                 // If removed
                 return;
             }
+
+            // Use min_rect after content is shown to get actual content bounds.
+            // This ensures pin is aligned with actual content, not pre-allocated space.
+            let content_rect = pin_ui.min_rect();
+            let y0 = content_rect.min.y;
+            let y1 = content_rect.max.y;
 
             let pin_rect = snarl_pin.pin_rect(
                 output_x,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -604,20 +604,20 @@ pub struct SnarlStyle {
 }
 
 impl SnarlStyle {
-    fn get_node_layout(&self) -> NodeLayout {
+    fn node_layout(&self) -> NodeLayout {
         self.node_layout.unwrap_or_default()
     }
 
-    fn get_pin_size(&self, style: &Style) -> f32 {
+    fn pin_size(&self, style: &Style) -> f32 {
         self.pin_size.unwrap_or(style.spacing.interact_size.y * 0.6)
     }
 
-    fn get_pin_fill(&self, style: &Style) -> Color32 {
+    pub(crate) fn pin_fill(&self, style: &Style) -> Color32 {
         self.pin_fill
             .unwrap_or(style.visuals.widgets.active.bg_fill)
     }
 
-    fn get_pin_stroke(&self, style: &Style) -> Stroke {
+    pub(crate) fn pin_stroke(&self, style: &Style) -> Stroke {
         self.pin_stroke.unwrap_or_else(|| {
             Stroke::new(
                 style.visuals.widgets.active.bg_stroke.width,
@@ -626,80 +626,80 @@ impl SnarlStyle {
         })
     }
 
-    fn get_pin_shape(&self) -> PinShape {
+    pub(crate) fn pin_shape(&self) -> PinShape {
         self.pin_shape.unwrap_or(PinShape::Circle)
     }
 
-    fn get_pin_placement(&self) -> PinPlacement {
+    fn pin_placement(&self) -> PinPlacement {
         self.pin_placement.unwrap_or_default()
     }
 
-    fn get_wire_width(&self, style: &Style) -> f32 {
+    fn wire_width(&self, style: &Style) -> f32 {
         self.wire_width
-            .unwrap_or_else(|| self.get_pin_size(style) * 0.1)
+            .unwrap_or_else(|| self.pin_size(style) * 0.1)
     }
 
-    fn get_wire_frame_size(&self, style: &Style) -> f32 {
+    fn wire_frame_size(&self, style: &Style) -> f32 {
         self.wire_frame_size
-            .unwrap_or_else(|| self.get_pin_size(style) * 3.0)
+            .unwrap_or_else(|| self.pin_size(style) * 3.0)
     }
 
-    fn get_downscale_wire_frame(&self) -> bool {
+    fn downscale_wire_frame(&self) -> bool {
         self.downscale_wire_frame.unwrap_or(true)
     }
 
-    fn get_upscale_wire_frame(&self) -> bool {
+    fn upscale_wire_frame(&self) -> bool {
         self.upscale_wire_frame.unwrap_or(false)
     }
 
-    fn get_wire_style(&self) -> WireStyle {
+    pub(crate) fn wire_style(&self) -> WireStyle {
         self.wire_style.unwrap_or(WireStyle::Bezier5)
     }
 
-    fn get_wire_layer(&self) -> WireLayer {
+    fn wire_layer(&self) -> WireLayer {
         self.wire_layer.unwrap_or(WireLayer::BehindNodes)
     }
 
-    fn get_header_drag_space(&self, style: &Style) -> Vec2 {
+    fn header_drag_space(&self, style: &Style) -> Vec2 {
         self.header_drag_space
             .unwrap_or_else(|| vec2(style.spacing.icon_width, style.spacing.icon_width))
     }
 
-    fn get_collapsible(&self) -> bool {
+    fn collapsible(&self) -> bool {
         self.collapsible.unwrap_or(true)
     }
 
-    fn get_bg_frame(&self, style: &Style) -> Frame {
+    fn bg_frame(&self, style: &Style) -> Frame {
         self.bg_frame.unwrap_or_else(|| Frame::canvas(style))
     }
 
-    fn get_bg_pattern_stroke(&self, style: &Style) -> Stroke {
+    pub(crate) fn bg_pattern_stroke(&self, style: &Style) -> Stroke {
         self.bg_pattern_stroke
             .unwrap_or(style.visuals.widgets.noninteractive.bg_stroke)
     }
 
-    fn get_min_scale(&self) -> f32 {
+    fn min_scale(&self) -> f32 {
         self.min_scale.unwrap_or(0.2)
     }
 
-    fn get_max_scale(&self) -> f32 {
+    fn max_scale(&self) -> f32 {
         self.max_scale.unwrap_or(2.0)
     }
 
-    fn get_node_frame(&self, style: &Style) -> Frame {
+    fn node_frame(&self, style: &Style) -> Frame {
         self.node_frame.unwrap_or_else(|| Frame::window(style))
     }
 
-    fn get_header_frame(&self, style: &Style) -> Frame {
+    fn header_frame(&self, style: &Style) -> Frame {
         self.header_frame
-            .unwrap_or_else(|| self.get_node_frame(style).shadow(Shadow::NONE))
+            .unwrap_or_else(|| self.node_frame(style).shadow(Shadow::NONE))
     }
 
-    fn get_centering(&self) -> bool {
+    fn centering(&self) -> bool {
         self.centering.unwrap_or(true)
     }
 
-    fn get_select_stroke(&self, style: &Style) -> Stroke {
+    fn select_stroke(&self, style: &Style) -> Stroke {
         self.select_stoke.unwrap_or_else(|| {
             Stroke::new(
                 style.visuals.selection.stroke.width,
@@ -708,33 +708,33 @@ impl SnarlStyle {
         })
     }
 
-    fn get_select_fill(&self, style: &Style) -> Color32 {
+    fn select_fill(&self, style: &Style) -> Color32 {
         self.select_fill
             .unwrap_or_else(|| style.visuals.selection.bg_fill.gamma_multiply(0.3))
     }
 
-    fn get_select_rect_contained(&self) -> bool {
+    fn select_rect_contained(&self) -> bool {
         self.select_rect_contained.unwrap_or(false)
     }
 
-    fn get_select_style(&self, style: &Style) -> SelectionStyle {
+    fn select_style(&self, style: &Style) -> SelectionStyle {
         self.select_style.unwrap_or_else(|| SelectionStyle {
             margin: style.spacing.window_margin,
             rounding: style.visuals.window_corner_radius,
-            fill: self.get_select_fill(style),
-            stroke: self.get_select_stroke(style),
+            fill: self.select_fill(style),
+            stroke: self.select_stroke(style),
         })
     }
 
-    fn get_crisp_magnified_text(&self) -> bool {
+    fn crisp_magnified_text(&self) -> bool {
         self.crisp_magnified_text.unwrap_or(false)
     }
 
-    fn get_wire_smoothness(&self) -> f32 {
+    fn wire_smoothness(&self) -> f32 {
         self.wire_smoothness.unwrap_or(1.0)
     }
 
-    fn get_pin_hover_scale(&self) -> f32 {
+    fn pin_hover_scale(&self) -> f32 {
         self.pin_hover_scale.unwrap_or(1.2)
     }
 }
@@ -1025,7 +1025,7 @@ where
         )
     });
 
-    let bg_frame = style.get_bg_frame(ui.style());
+    let bg_frame = style.bg_frame(ui.style());
 
     let outer_size_bounds = ui.available_size_before_wrap().max(min_size).min(max_size);
 
@@ -1043,8 +1043,8 @@ where
 
     ui.ctx().set_sublayer(ui.layer_id(), snarl_layer_id);
 
-    let mut min_scale = style.get_min_scale();
-    let mut max_scale = style.get_max_scale();
+    let mut min_scale = style.min_scale();
+    let mut max_scale = style.max_scale();
 
     let ui_rect = content_rect;
 
@@ -1078,7 +1078,7 @@ where
             .sense(Sense::click_and_drag()),
     );
 
-    if style.get_crisp_magnified_text() {
+    if style.crisp_magnified_text() {
         style.scale(max_scale);
         ui.style_mut().scale(max_scale);
 
@@ -1158,11 +1158,11 @@ where
         }
     }
 
-    let wire_frame_size = style.get_wire_frame_size(ui.style());
-    let wire_width = style.get_wire_width(ui.style());
-    let wire_threshold = style.get_wire_smoothness();
+    let wire_frame_size = style.wire_frame_size(ui.style());
+    let wire_width = style.wire_width(ui.style());
+    let wire_threshold = style.wire_smoothness();
 
-    let wire_shape_idx = match style.get_wire_layer() {
+    let wire_shape_idx = match style.wire_layer() {
         WireLayer::BehindNodes => Some(ui.painter().add(Shape::Noop)),
         WireLayer::AboveNodes => None,
     };
@@ -1259,8 +1259,8 @@ where
                         in_pin: wire.in_pin,
                     },
                     wire_frame_size,
-                    style.get_upscale_wire_frame(),
-                    style.get_downscale_wire_frame(),
+                    style.upscale_wire_frame(),
+                    style.downscale_wire_frame(),
                     from_r.pos,
                     to_r.pos,
                     latest_pos,
@@ -1297,8 +1297,8 @@ where
             },
             &mut wire_shapes,
             wire_frame_size,
-            style.get_upscale_wire_frame(),
-            style.get_downscale_wire_frame(),
+            style.upscale_wire_frame(),
+            style.downscale_wire_frame(),
             from_r.pos,
             to_r.pos,
             Stroke::new(draw_width, color),
@@ -1329,7 +1329,7 @@ where
         let mut select_nodes: Vec<NodeId> = node_rects
             .into_iter()
             .filter_map(|(id, rect)| {
-                let select = if style.get_select_rect_contained() {
+                let select = if style.select_rect_contained() {
                     select_rect.contains_rect(rect)
                 } else {
                     select_rect.intersects(rect)
@@ -1360,8 +1360,8 @@ where
         ui.painter().rect(
             select_rect,
             0.0,
-            style.get_select_fill(ui.style()),
-            style.get_select_stroke(ui.style()),
+            style.select_fill(ui.style()),
+            style.select_stroke(ui.style()),
             StrokeKind::Inside,
         );
     }
@@ -1380,7 +1380,7 @@ where
     }
 
     // Do centering unless no nodes are present.
-    if style.get_centering() && snarl_resp.double_clicked() && nodes_bb.is_finite() {
+    if style.centering() && snarl_resp.double_clicked() && nodes_bb.is_finite() {
         let nodes_bb = nodes_bb.expand(100.0);
         snarl_state.look_at(nodes_bb, ui_rect, min_scale, max_scale);
     }
@@ -1501,8 +1501,8 @@ where
                     WireId::NewInput { snarl_id, in_pin },
                     &mut wire_shapes,
                     wire_frame_size,
-                    style.get_upscale_wire_frame(),
-                    style.get_downscale_wire_frame(),
+                    style.upscale_wire_frame(),
+                    style.downscale_wire_frame(),
                     from_pos,
                     to_r.pos,
                     Stroke::new(wire_width, to_r.wire_color),
@@ -1521,8 +1521,8 @@ where
                     WireId::NewOutput { snarl_id, out_pin },
                     &mut wire_shapes,
                     wire_frame_size,
-                    style.get_upscale_wire_frame(),
-                    style.get_downscale_wire_frame(),
+                    style.upscale_wire_frame(),
+                    style.downscale_wire_frame(),
                     from_r.pos,
                     to_pos,
                     Stroke::new(wire_width, from_r.wire_color),
@@ -1781,7 +1781,7 @@ where
                     }
                 }
                 pin_hovered = Some(AnyPin::In(in_pin.id));
-                visual_pin_rect = visual_pin_rect.scale_from_center(style.get_pin_hover_scale());
+                visual_pin_rect = visual_pin_rect.scale_from_center(style.pin_hover_scale());
             }
 
             let wire_info =
@@ -1946,7 +1946,7 @@ where
                     }
                 }
                 pin_hovered = Some(AnyPin::Out(out_pin.id));
-                visual_pin_rect = visual_pin_rect.scale_from_center(style.get_pin_hover_scale());
+                visual_pin_rect = visual_pin_rect.scale_from_center(style.pin_hover_scale());
             }
 
             let wire_info =
@@ -2066,7 +2066,7 @@ where
     let mut pin_hovered = None;
 
     let node_frame = viewer.node_frame(
-        style.get_node_frame(ui.style()),
+        style.node_frame(ui.style()),
         node,
         &inputs,
         &outputs,
@@ -2074,7 +2074,7 @@ where
     );
 
     let header_frame = viewer.header_frame(
-        style.get_header_frame(ui.style()),
+        style.header_frame(ui.style()),
         node,
         &inputs,
         &outputs,
@@ -2085,7 +2085,7 @@ where
     let node_frame_rect = node_rect + node_frame.total_margin();
 
     if snarl_state.selected_nodes().contains(&node) {
-        let select_style = style.get_select_style(ui.style());
+        let select_style = style.select_style(ui.style());
 
         let select_rect = node_frame_rect + select_style.margin;
 
@@ -2100,11 +2100,11 @@ where
 
     // Size of the pin.
     // Side of the square or diameter of the circle.
-    let pin_size = style.get_pin_size(ui.style()).max(0.0);
+    let pin_size = style.pin_size(ui.style()).max(0.0);
 
-    let pin_placement = style.get_pin_placement();
+    let pin_placement = style.pin_placement();
 
-    let header_drag_space = style.get_header_drag_space(ui.style()).max(Vec2::ZERO);
+    let header_drag_space = style.header_drag_space(ui.style()).max(Vec2::ZERO);
 
     // Interact with node frame.
     let r = ui.interact(
@@ -2238,7 +2238,7 @@ where
         );
 
         let node_layout =
-            viewer.node_layout(style.get_node_layout(), node, &inputs, &outputs, snarl);
+            viewer.node_layout(style.node_layout(), node, &inputs, &outputs, snarl);
 
         let payload_clip_rect =
             Rect::from_min_max(node_rect.min, pos2(node_rect.max.x, f32::INFINITY));
@@ -2670,7 +2670,7 @@ where
 
         header_frame.show(header_ui, |ui: &mut Ui| {
             ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
-                if style.get_collapsible() {
+                if style.collapsible() {
                     let (_, r) = ui.allocate_exact_size(
                         vec2(ui.spacing().icon_width, ui.spacing().icon_width),
                         Sense::click(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1035,6 +1035,12 @@ where
 
     let mut snarl_state =
         SnarlState::load(ui.ctx(), snarl_id, snarl, ui_rect, min_scale, max_scale);
+
+    // Allow viewer to update selection before rendering
+    if let Some(selection) = viewer.update_selection(snarl_state.selected_nodes()) {
+        snarl_state.select_many_nodes(true, selection.iter().cloned());
+    }
+
     let mut to_global = snarl_state.to_global();
 
     let clip_rect = ui.clip_rect();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,8 +4,8 @@ use std::{collections::HashMap, hash::Hash};
 
 use egui::{
     collapsing_header::paint_default_icon, epaint::Shadow, pos2, vec2, Align, Color32, Frame, Id,
-    Layout, Margin, Modifiers, PointerButton, Pos2, Rect, Rounding, Sense, Shape, Stroke, Style,
-    Ui, UiBuilder, Vec2,
+    Key, Layout, Margin, Modifiers, PointerButton, Pos2, Rect, Rounding, Sense, Shape, Stroke,
+    Style, Ui, UiBuilder, Vec2,
 };
 
 use crate::{InPin, InPinId, Node, NodeId, OutPin, OutPinId, Snarl};
@@ -590,6 +590,7 @@ struct Input {
     // primary_pressed: bool,
     secondary_pressed: bool,
     modifiers: Modifiers,
+    escape_pressed: bool,
 }
 
 struct DrawNodeResponse {
@@ -662,6 +663,7 @@ impl<T> Snarl<T> {
             modifiers: i.modifiers,
             // primary_pressed: i.pointer.primary_pressed(),
             secondary_pressed: i.pointer.secondary_pressed(),
+            escape_pressed: i.key_pressed(Key::Escape),
         });
 
         bg_frame.show(ui, |ui| {
@@ -914,7 +916,9 @@ impl<T> Snarl<T> {
                 snarl_state.set_offset(centers_sum * snarl_state.scale());
             }
 
-            if input.modifiers.command && bg_r.clicked_by(PointerButton::Primary) {
+            if input.modifiers.command && bg_r.clicked_by(PointerButton::Primary)
+                || input.escape_pressed
+            {
                 snarl_state.deselect_all_nodes();
             }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,9 +3,8 @@
 use std::{collections::HashMap, hash::Hash};
 
 use egui::{
-    Align, Color32, CornerRadius, Frame, Id, LayerId, Layout, Margin, Modifiers, PointerButton,
-    Pos2, Rect, Scene, Sense, Shape, Stroke, StrokeKind, Style, Ui, UiBuilder, UiKind, UiStackInfo,
-    Vec2,
+    Align, Color32, CornerRadius, Frame, Id, LayerId, Layout, Margin, Modifiers, Pos2, Rect, Scene,
+    Sense, Shape, Stroke, StrokeKind, Style, Ui, UiBuilder, UiKind, UiStackInfo, Vec2,
     collapsing_header::paint_default_icon,
     emath::{GuiRounding, TSTransform},
     epaint::Shadow,
@@ -18,6 +17,7 @@ use egui_scale::EguiScale;
 use crate::{InPin, InPinId, Node, NodeId, OutPin, OutPinId, Snarl};
 
 mod background_pattern;
+mod config;
 mod pin;
 mod scale;
 mod state;
@@ -32,6 +32,7 @@ use self::{
 
 pub use self::{
     background_pattern::{BackgroundPattern, Grid},
+    config::{ModifierClick, SnarlConfig},
     pin::{AnyPins, PinInfo, PinShape, PinWireInfo, SnarlPin},
     state::get_selected_nodes,
     viewer::SnarlViewer,
@@ -639,6 +640,7 @@ pub struct SnarlWidget {
     id_salt: Id,
     id: Option<Id>,
     style: SnarlStyle,
+    config: SnarlConfig,
     min_size: Vec2,
     max_size: Vec2,
 }
@@ -659,6 +661,7 @@ impl SnarlWidget {
             id_salt: Id::new(":snarl:"),
             id: None,
             style: SnarlStyle::new(),
+            config: SnarlConfig::new(),
             min_size: Vec2::ZERO,
             max_size: Vec2::INFINITY,
         }
@@ -697,6 +700,14 @@ impl SnarlWidget {
         self
     }
 
+    /// Set config parameters for the [`Snarl`] widget.
+    #[inline]
+    #[must_use]
+    pub fn config(mut self, config: SnarlConfig) -> Self {
+        self.config = config;
+        self
+    }
+
     /// Set minimum size of the [`Snarl`] widget.
     #[inline]
     #[must_use]
@@ -729,6 +740,7 @@ impl SnarlWidget {
         show_snarl(
             snarl_id,
             self.style,
+            self.config,
             self.min_size,
             self.max_size,
             snarl,
@@ -742,6 +754,7 @@ impl SnarlWidget {
 fn show_snarl<T, V>(
     snarl_id: Id,
     mut style: SnarlStyle,
+    mut config: SnarlConfig,
     min_size: Vec2,
     max_size: Vec2,
     snarl: &mut Snarl<T>,
@@ -846,10 +859,10 @@ where
 
     // Process selection rect.
     let mut rect_selection_ended = None;
-    if modifiers.shift || snarl_state.is_rect_selection() {
+    if modifiers == config.rect_select.modifiers || snarl_state.is_rect_selection() {
         let select_resp = ui.interact(snarl_resp.rect, snarl_id.with("select"), Sense::drag());
 
-        if select_resp.dragged_by(PointerButton::Primary) {
+        if select_resp.dragged_by(config.rect_select.mouse_button) {
             if let Some(pos) = select_resp.interact_pointer_pos() {
                 if snarl_state.is_rect_selection() {
                     snarl_state.update_rect_selection(pos);
@@ -859,7 +872,7 @@ where
             }
         }
 
-        if select_resp.drag_stopped_by(PointerButton::Primary) {
+        if select_resp.drag_stopped_by(config.rect_select.mouse_button) {
             if let Some(select_rect) = snarl_state.rect_selection() {
                 rect_selection_ended = Some(select_rect);
             }
@@ -899,6 +912,7 @@ where
             node_idx,
             viewer,
             &mut snarl_state,
+            &mut config,
             &style,
             snarl_id,
             &mut input_info,
@@ -966,7 +980,8 @@ where
                         ui.interact(snarl_resp.rect, ui.make_persistent_id(wire), Sense::click());
 
                     //Remove hovered wire by second click
-                    hovered_wire_disconnect |= wire_r.clicked_by(PointerButton::Secondary);
+                    hovered_wire_disconnect |=
+                        wire_r.clicked_by(config.remove_hovered_wire.mouse_button);
                 }
             }
         }
@@ -1014,10 +1029,13 @@ where
             if select { Some(id) } else { None }
         });
 
-        if modifiers.command {
+        if modifiers.contains(config.deselect_all_nodes.modifiers) {
             snarl_state.deselect_many_nodes(select_nodes);
         } else {
-            snarl_state.select_many_nodes(!modifiers.shift, select_nodes);
+            snarl_state.select_many_nodes(
+                !modifiers.contains(config.rect_select.modifiers),
+                select_nodes,
+            );
         }
     }
 
@@ -1037,7 +1055,8 @@ where
     //
     // This uses `button_down` directly, instead of `clicked_by` to improve
     // responsiveness of the cancel action.
-    if snarl_state.has_new_wires() && ui.input(|x| x.pointer.button_down(PointerButton::Secondary))
+    if snarl_state.has_new_wires()
+        && ui.input(|x| x.pointer.button_down(config.cancel_wire_drag.mouse_button))
     {
         let _ = snarl_state.take_new_wires();
         snarl_resp.flags.remove(Flags::CLICKED);
@@ -1049,7 +1068,9 @@ where
         snarl_state.look_at(nodes_bb, ui_rect, min_scale, max_scale);
     }
 
-    if modifiers.command && snarl_resp.clicked_by(PointerButton::Primary) {
+    if modifiers == config.deselect_all_nodes.modifiers
+        && snarl_resp.clicked_by(config.deselect_all_nodes.mouse_button)
+    {
         snarl_state.deselect_all_nodes();
     }
 
@@ -1235,6 +1256,7 @@ fn draw_inputs<T, V>(
     min_pin_y: f32,
     input_spacing: Option<f32>,
     snarl_state: &mut SnarlState,
+    config: &mut SnarlConfig,
     modifiers: Modifiers,
     input_positions: &mut HashMap<InPinId, PinResponse>,
 ) -> DrawPinsResponse
@@ -1283,7 +1305,7 @@ where
 
             ui.skip_ahead_auto_ids(1);
 
-            if r.clicked_by(PointerButton::Secondary) {
+            if r.clicked_by(config.click_pin.mouse_button) {
                 if snarl_state.has_new_wires() {
                     snarl_state.remove_new_wire_in(in_pin.id);
                 } else {
@@ -1294,10 +1316,12 @@ where
                     }
                 }
             }
-            if r.drag_started_by(PointerButton::Primary) {
+            if r.drag_started_by(config.drag_pin.mouse_button) {
+                // TODO: I am not sure what start_new_wires_out() does?
+                // Is that for a future feature where you can draw several wires at once?
                 if modifiers.command {
                     snarl_state.start_new_wires_out(&in_pin.remotes);
-                    if !modifiers.shift {
+                    if modifiers != config.drag_pin.modifiers {
                         snarl.drop_inputs(in_pin.id);
                         if !snarl.nodes.contains(node.0) {
                             // If removed
@@ -1317,6 +1341,7 @@ where
 
             if r.contains_pointer() {
                 if snarl_state.has_new_wires_in() {
+                    // TODO: And here I am also not sure what these modifiers do
                     if modifiers.shift && !modifiers.command {
                         snarl_state.add_new_wire_in(in_pin.id);
                     }
@@ -1366,6 +1391,7 @@ fn draw_outputs<T, V>(
     min_pin_y: f32,
     output_spacing: Option<f32>,
     snarl_state: &mut SnarlState,
+    config: &mut SnarlConfig,
     modifiers: Modifiers,
     output_positions: &mut HashMap<OutPinId, PinResponse>,
 ) -> DrawPinsResponse
@@ -1414,7 +1440,7 @@ where
 
             ui.skip_ahead_auto_ids(1);
 
-            if r.clicked_by(PointerButton::Secondary) {
+            if r.clicked_by(config.click_pin.mouse_button) {
                 if snarl_state.has_new_wires() {
                     snarl_state.remove_new_wire_out(out_pin.id);
                 } else {
@@ -1425,11 +1451,11 @@ where
                     }
                 }
             }
-            if r.drag_started_by(PointerButton::Primary) {
-                if modifiers.command {
+            if r.drag_started_by(config.drag_pin.mouse_button) {
+                if modifiers.contains(config.drag_pin.modifiers) {
                     snarl_state.start_new_wires_in(&out_pin.remotes);
 
-                    if !modifiers.shift {
+                    if !modifiers.contains(config.no_menu.modifiers) {
                         snarl.drop_outputs(out_pin.id);
                         if !snarl.nodes.contains(node.0) {
                             // If removed
@@ -1447,6 +1473,7 @@ where
             let mut visual_pin_rect = r.rect;
 
             if r.contains_pointer() {
+                // TODO: What is happening here?
                 if snarl_state.has_new_wires_out() {
                     if modifiers.shift && !modifiers.command {
                         snarl_state.add_new_wire_out(out_pin.id);
@@ -1525,6 +1552,7 @@ fn draw_node<T, V>(
     node: NodeId,
     viewer: &mut V,
     snarl_state: &mut SnarlState,
+    config: &mut SnarlConfig,
     style: &SnarlStyle,
     snarl_id: Id,
     input_positions: &mut HashMap<InPinId, PinResponse>,
@@ -1616,14 +1644,17 @@ where
         Sense::click_and_drag(),
     );
 
-    if !modifiers.shift && !modifiers.command && r.dragged_by(PointerButton::Primary) {
+    if !modifiers.contains(config.select_node.modifiers)
+        && !modifiers.contains(config.deselect_node.modifiers)
+        && r.dragged_by(config.click_node.mouse_button)
+    {
         node_moved = Some((node, r.drag_delta()));
     }
 
-    if r.clicked_by(PointerButton::Primary) || r.dragged_by(PointerButton::Primary) {
-        if modifiers.shift {
+    if r.clicked_by(config.click_node.mouse_button) || r.dragged_by(config.drag_node.mouse_button) {
+        if modifiers.contains(config.select_node.modifiers) {
             snarl_state.select_one_node(modifiers.command, node);
-        } else if modifiers.command {
+        } else if modifiers.contains(config.deselect_node.modifiers) {
             snarl_state.deselect_one_node(node);
         }
     }
@@ -1760,6 +1791,7 @@ where
                     min_pin_y,
                     input_spacing,
                     snarl_state,
+                    config,
                     modifiers,
                     input_positions,
                 );
@@ -1794,6 +1826,7 @@ where
                     min_pin_y,
                     output_spacing,
                     snarl_state,
+                    config,
                     modifiers,
                     output_positions,
                 );
@@ -1874,6 +1907,7 @@ where
                     min_pin_y,
                     input_spacing,
                     snarl_state,
+                    config,
                     modifiers,
                     input_positions,
                 );
@@ -1945,6 +1979,7 @@ where
                     min_pin_y,
                     output_spacing,
                     snarl_state,
+                    config,
                     modifiers,
                     output_positions,
                 );
@@ -1987,6 +2022,7 @@ where
                     min_pin_y,
                     output_spacing,
                     snarl_state,
+                    config,
                     modifiers,
                     output_positions,
                 );
@@ -2058,6 +2094,7 @@ where
                     min_pin_y,
                     input_spacing,
                     snarl_state,
+                    config,
                     modifiers,
                     input_positions,
                 );
@@ -2138,7 +2175,7 @@ where
                     );
                     paint_default_icon(ui, openness, &r);
 
-                    if r.clicked_by(PointerButton::Primary) {
+                    if r.clicked_by(config.click_header.mouse_button) {
                         // Toggle node's openness.
                         snarl.open_node(node, !open);
                     }
@@ -2276,13 +2313,20 @@ const fn mix_colors(a: Color32, b: Color32) -> Color32 {
 impl<T> Snarl<T> {
     /// Render [`Snarl`] using given viewer and style into the [`Ui`].
     #[inline]
-    pub fn show<V>(&mut self, viewer: &mut V, style: &SnarlStyle, id_salt: impl Hash, ui: &mut Ui)
-    where
+    pub fn show<V>(
+        &mut self,
+        viewer: &mut V,
+        style: &SnarlStyle,
+        config: &SnarlConfig,
+        id_salt: impl Hash,
+        ui: &mut Ui,
+    ) where
         V: SnarlViewer<T>,
     {
         show_snarl(
             ui.make_persistent_id(id_salt),
             *style,
+            *config,
             Vec2::ZERO,
             Vec2::INFINITY,
             self,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 //! This module provides functionality for showing [`Snarl`] graph in [`Ui`].
 
-use std::{collections::HashMap, hash::Hash};
+use std::{collections::HashMap, hash::Hash, ops::Add};
 
 use egui::{
     Align, Color32, CornerRadius, Frame, Id, LayerId, Layout, Margin, Modifiers, PointerButton,
@@ -1114,6 +1114,7 @@ where
     let mut hovered_wire = None;
     let mut hovered_wire_disconnect = false;
     let mut wire_shapes = Vec::new();
+    let mut wire_widgets = Vec::new();
 
     // Draw and interact with wires
     for wire in snarl.wires.iter() {
@@ -1183,6 +1184,16 @@ where
             wire_threshold,
             pick_wire_style(from_r.wire_style, to_r.wire_style),
         );
+        if viewer.has_wire_widget(&wire.out_pin, &wire.in_pin, snarl) {
+            wire_widgets.push((
+                snarl.out_pin(wire.out_pin),
+                snarl.in_pin(wire.in_pin),
+                Pos2 {
+                    x: (from_r.pos.x + to_r.pos.x) / 2.0,
+                    y: (from_r.pos.y + to_r.pos.y) / 2.0,
+                },
+            ));
+        }
     }
 
     // Remove hovered wire by second click
@@ -1378,6 +1389,22 @@ where
         Some(idx) => {
             ui.painter().set(idx, Shape::Vec(wire_shapes));
         }
+    }
+
+    for (out_pin, in_pin, pos) in wire_widgets {
+        let rect = Rect::from_center_size(
+            pos.add(Vec2::from([0.0, -10.0])), // add the widget little above the wire
+            Vec2::from([200.0, 20.0]),
+        );
+        let wire_ui = &mut ui.new_child(
+            UiBuilder::new()
+                .max_rect(rect.round_ui())
+                .layout(Layout::centered_and_justified(egui::Direction::LeftToRight))
+                .id_salt(Id::new("wire widget")),
+        );
+        egui::Frame::new().show(wire_ui, |ui| {
+            viewer.show_wire_widget(&out_pin, &in_pin, ui, snarl);
+        });
     }
 
     ui.advance_cursor_after_rect(Rect::from_min_size(snarl_resp.rect.min, Vec2::ZERO));

--- a/src/ui/background_pattern.rs
+++ b/src/ui/background_pattern.rs
@@ -47,7 +47,7 @@ impl Grid {
     }
 
     fn draw(&self, viewport: &Rect, snarl_style: &SnarlStyle, style: &Style, painter: &Painter) {
-        let bg_stroke = snarl_style.get_bg_pattern_stroke(style);
+        let bg_stroke = snarl_style.bg_pattern_stroke(style);
 
         let spacing = vec2(self.spacing.x.max(1.0), self.spacing.y.max(1.0));
 

--- a/src/ui/background_pattern.rs
+++ b/src/ui/background_pattern.rs
@@ -1,4 +1,4 @@
-use egui::{emath::Rot2, vec2, Painter, Rect, Style, Vec2};
+use egui::{Painter, Rect, Style, Vec2, emath::Rot2, vec2};
 
 use super::SnarlStyle;
 

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -65,6 +65,11 @@ pub struct SnarlConfig {
     /// Defaults to [`PointerButton::Primary`].
     pub click_header: ModifierClick,
 
+    /// When true, only a single node can be selected at a time.
+    /// Clicking a node will deselect any previously selected nodes.
+    /// Defaults to `false`.
+    pub single_select: bool,
+
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
     /// Do not access other than with .., here to emulate `#[non_exhaustive(pub)]`
@@ -130,6 +135,8 @@ impl SnarlConfig {
                 modifiers: Modifiers::NONE,
                 mouse_button: PointerButton::Primary,
             },
+
+            single_select: false,
 
             _non_exhaustive: (),
         }

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -14,8 +14,10 @@ pub struct ModifierClick {
 /// Type of snap grid for node positioning.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default)]
 pub enum SnapGridType {
     /// Square/rectangular grid.
+    #[default]
     Quad,
     /// Hexagonal grid with pointy tops (vertical orientation).
     /// Rows are offset horizontally.
@@ -23,12 +25,6 @@ pub enum SnapGridType {
     /// Hexagonal grid with flat tops (horizontal orientation).
     /// Columns are offset vertically.
     HexFlat,
-}
-
-impl Default for SnapGridType {
-    fn default() -> Self {
-        Self::Quad
-    }
 }
 
 /// Configuration for snap grid.
@@ -179,14 +175,17 @@ impl SnapGrid {
     /// Get the effective stroke for drawing the grid.
     #[must_use]
     pub fn stroke(&self) -> Stroke {
-        let color = self.color.unwrap_or(Color32::from_rgba_unmultiplied(128, 128, 128, 80));
+        let color = self
+            .color
+            .unwrap_or(Color32::from_rgba_unmultiplied(128, 128, 128, 80));
         Stroke::new(1.0, color)
     }
 
     /// Get the effective color for drawing points.
     #[must_use]
     pub fn point_color(&self) -> Color32 {
-        self.color.unwrap_or(Color32::from_rgba_unmultiplied(128, 128, 128, 120))
+        self.color
+            .unwrap_or(Color32::from_rgba_unmultiplied(128, 128, 128, 120))
     }
 
     /// Draw the snap grid within the given viewport.
@@ -231,7 +230,11 @@ impl SnapGrid {
 
         for row in min_row..=max_row {
             let y = row as f32 * vert_spacing;
-            let x_offset = if row.abs() % 2 == 1 { horiz_spacing / 2.0 } else { 0.0 };
+            let x_offset = if row.abs() % 2 == 1 {
+                horiz_spacing / 2.0
+            } else {
+                0.0
+            };
 
             for col in min_col..=max_col {
                 let x = col as f32 * horiz_spacing + x_offset;
@@ -254,7 +257,11 @@ impl SnapGrid {
 
         for col in min_col..=max_col {
             let x = col as f32 * horiz_spacing;
-            let y_offset = if col.abs() % 2 == 1 { vert_spacing / 2.0 } else { 0.0 };
+            let y_offset = if col.abs() % 2 == 1 {
+                vert_spacing / 2.0
+            } else {
+                0.0
+            };
 
             for row in min_row..=max_row {
                 let y = row as f32 * vert_spacing + y_offset;

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -70,6 +70,12 @@ pub struct SnarlConfig {
     /// Defaults to `false`.
     pub single_select: bool,
 
+    /// Grid size for snapping node positions.
+    /// When `Some(size)`, nodes will snap to a grid with the specified cell size.
+    /// Set to `None` to disable grid snapping.
+    /// Defaults to `None`.
+    pub grid_snap: Option<f32>,
+
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
     /// Do not access other than with .., here to emulate `#[non_exhaustive(pub)]`
@@ -137,6 +143,8 @@ impl SnarlConfig {
             },
 
             single_select: false,
+
+            grid_snap: None,
 
             _non_exhaustive: (),
         }

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1,4 +1,4 @@
-use egui::{Modifiers, PointerButton};
+use egui::{Color32, Modifiers, Painter, PointerButton, Pos2, Rect, Stroke};
 
 /// Struct holding keyboard modifiers and mouse button.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9,6 +9,262 @@ pub struct ModifierClick {
 
     /// Mouse buttons for this action.
     pub mouse_button: PointerButton,
+}
+
+/// Type of snap grid for node positioning.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SnapGridType {
+    /// Square/rectangular grid.
+    Quad,
+    /// Hexagonal grid with pointy tops (vertical orientation).
+    /// Rows are offset horizontally.
+    HexPointy,
+    /// Hexagonal grid with flat tops (horizontal orientation).
+    /// Columns are offset vertically.
+    HexFlat,
+}
+
+impl Default for SnapGridType {
+    fn default() -> Self {
+        Self::Quad
+    }
+}
+
+/// Configuration for snap grid.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SnapGrid {
+    /// The size of each grid cell.
+    pub size: f32,
+    /// The type of grid (quad or hex).
+    pub grid_type: SnapGridType,
+    /// Whether to show the grid visually.
+    pub visible: bool,
+    /// Color for grid points/lines when visible.
+    /// If None, uses a default semi-transparent color.
+    pub color: Option<Color32>,
+    /// Size of the snap point indicators when visible.
+    /// Defaults to 3.0.
+    pub point_size: f32,
+}
+
+impl Default for SnapGrid {
+    fn default() -> Self {
+        Self {
+            size: 25.0,
+            grid_type: SnapGridType::Quad,
+            visible: false,
+            color: None,
+            point_size: 3.0,
+        }
+    }
+}
+
+impl SnapGrid {
+    /// Create a new quad snap grid with the given size.
+    #[must_use]
+    pub const fn quad(size: f32) -> Self {
+        Self {
+            size,
+            grid_type: SnapGridType::Quad,
+            visible: false,
+            color: None,
+            point_size: 3.0,
+        }
+    }
+
+    /// Create a new pointy-top hex snap grid with the given size.
+    #[must_use]
+    pub const fn hex_pointy(size: f32) -> Self {
+        Self {
+            size,
+            grid_type: SnapGridType::HexPointy,
+            visible: false,
+            color: None,
+            point_size: 3.0,
+        }
+    }
+
+    /// Create a new flat-top hex snap grid with the given size.
+    #[must_use]
+    pub const fn hex_flat(size: f32) -> Self {
+        Self {
+            size,
+            grid_type: SnapGridType::HexFlat,
+            visible: false,
+            color: None,
+            point_size: 3.0,
+        }
+    }
+
+    /// Set the grid to be visible.
+    #[must_use]
+    pub const fn with_visible(mut self, visible: bool) -> Self {
+        self.visible = visible;
+        self
+    }
+
+    /// Set the grid color.
+    #[must_use]
+    pub const fn with_color(mut self, color: Color32) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    /// Set the snap point indicator size.
+    #[must_use]
+    pub const fn with_point_size(mut self, size: f32) -> Self {
+        self.point_size = size;
+        self
+    }
+
+    /// Snap a position to the nearest grid point.
+    #[must_use]
+    pub fn snap(&self, pos: Pos2) -> Pos2 {
+        match self.grid_type {
+            SnapGridType::Quad => self.snap_quad(pos),
+            SnapGridType::HexPointy => self.snap_hex_pointy(pos),
+            SnapGridType::HexFlat => self.snap_hex_flat(pos),
+        }
+    }
+
+    fn snap_quad(&self, pos: Pos2) -> Pos2 {
+        Pos2::new(
+            (pos.x / self.size).round() * self.size,
+            (pos.y / self.size).round() * self.size,
+        )
+    }
+
+    fn snap_hex_pointy(&self, pos: Pos2) -> Pos2 {
+        // Pointy-top hex: horizontal spacing is size, vertical spacing is size * sqrt(3)/2
+        // Odd rows are offset by size/2
+        let vert_spacing = self.size * 0.866_025_4; // sqrt(3)/2
+        let horiz_spacing = self.size;
+
+        // Find the row
+        let row = (pos.y / vert_spacing).round();
+        let snapped_y = row * vert_spacing;
+
+        // Determine if this is an odd row (offset)
+        #[allow(clippy::cast_possible_truncation)]
+        let is_odd_row = (row as i32).abs() % 2 == 1;
+        let x_offset = if is_odd_row { horiz_spacing / 2.0 } else { 0.0 };
+
+        let snapped_x = ((pos.x - x_offset) / horiz_spacing).round() * horiz_spacing + x_offset;
+
+        Pos2::new(snapped_x, snapped_y)
+    }
+
+    fn snap_hex_flat(&self, pos: Pos2) -> Pos2 {
+        // Flat-top hex: vertical spacing is size, horizontal spacing is size * sqrt(3)/2
+        // Odd columns are offset by size/2
+        let horiz_spacing = self.size * 0.866_025_4; // sqrt(3)/2
+        let vert_spacing = self.size;
+
+        // Find the column
+        let col = (pos.x / horiz_spacing).round();
+        let snapped_x = col * horiz_spacing;
+
+        // Determine if this is an odd column (offset)
+        #[allow(clippy::cast_possible_truncation)]
+        let is_odd_col = (col as i32).abs() % 2 == 1;
+        let y_offset = if is_odd_col { vert_spacing / 2.0 } else { 0.0 };
+
+        let snapped_y = ((pos.y - y_offset) / vert_spacing).round() * vert_spacing + y_offset;
+
+        Pos2::new(snapped_x, snapped_y)
+    }
+
+    /// Get the effective stroke for drawing the grid.
+    #[must_use]
+    pub fn stroke(&self) -> Stroke {
+        let color = self.color.unwrap_or(Color32::from_rgba_unmultiplied(128, 128, 128, 80));
+        Stroke::new(1.0, color)
+    }
+
+    /// Get the effective color for drawing points.
+    #[must_use]
+    pub fn point_color(&self) -> Color32 {
+        self.color.unwrap_or(Color32::from_rgba_unmultiplied(128, 128, 128, 120))
+    }
+
+    /// Draw the snap grid within the given viewport.
+    pub fn draw(&self, viewport: &Rect, painter: &Painter) {
+        if !self.visible {
+            return;
+        }
+
+        let color = self.point_color();
+        let point_size = self.point_size;
+
+        match self.grid_type {
+            SnapGridType::Quad => self.draw_quad(viewport, painter, color, point_size),
+            SnapGridType::HexPointy => self.draw_hex_pointy(viewport, painter, color, point_size),
+            SnapGridType::HexFlat => self.draw_hex_flat(viewport, painter, color, point_size),
+        }
+    }
+
+    fn draw_quad(&self, viewport: &Rect, painter: &Painter, color: Color32, point_size: f32) {
+        let min_x = (viewport.min.x / self.size).floor() as i32;
+        let max_x = (viewport.max.x / self.size).ceil() as i32;
+        let min_y = (viewport.min.y / self.size).floor() as i32;
+        let max_y = (viewport.max.y / self.size).ceil() as i32;
+
+        for xi in min_x..=max_x {
+            for yi in min_y..=max_y {
+                let x = xi as f32 * self.size;
+                let y = yi as f32 * self.size;
+                painter.circle_filled(Pos2::new(x, y), point_size, color);
+            }
+        }
+    }
+
+    fn draw_hex_pointy(&self, viewport: &Rect, painter: &Painter, color: Color32, point_size: f32) {
+        let vert_spacing = self.size * 0.866_025_4; // sqrt(3)/2
+        let horiz_spacing = self.size;
+
+        let min_row = (viewport.min.y / vert_spacing).floor() as i32 - 1;
+        let max_row = (viewport.max.y / vert_spacing).ceil() as i32 + 1;
+        let min_col = (viewport.min.x / horiz_spacing).floor() as i32 - 1;
+        let max_col = (viewport.max.x / horiz_spacing).ceil() as i32 + 1;
+
+        for row in min_row..=max_row {
+            let y = row as f32 * vert_spacing;
+            let x_offset = if row.abs() % 2 == 1 { horiz_spacing / 2.0 } else { 0.0 };
+
+            for col in min_col..=max_col {
+                let x = col as f32 * horiz_spacing + x_offset;
+                let pos = Pos2::new(x, y);
+                if viewport.contains(pos) {
+                    painter.circle_filled(pos, point_size, color);
+                }
+            }
+        }
+    }
+
+    fn draw_hex_flat(&self, viewport: &Rect, painter: &Painter, color: Color32, point_size: f32) {
+        let horiz_spacing = self.size * 0.866_025_4; // sqrt(3)/2
+        let vert_spacing = self.size;
+
+        let min_col = (viewport.min.x / horiz_spacing).floor() as i32 - 1;
+        let max_col = (viewport.max.x / horiz_spacing).ceil() as i32 + 1;
+        let min_row = (viewport.min.y / vert_spacing).floor() as i32 - 1;
+        let max_row = (viewport.max.y / vert_spacing).ceil() as i32 + 1;
+
+        for col in min_col..=max_col {
+            let x = col as f32 * horiz_spacing;
+            let y_offset = if col.abs() % 2 == 1 { vert_spacing / 2.0 } else { 0.0 };
+
+            for row in min_row..=max_row {
+                let y = row as f32 * vert_spacing + y_offset;
+                let pos = Pos2::new(x, y);
+                if viewport.contains(pos) {
+                    painter.circle_filled(pos, point_size, color);
+                }
+            }
+        }
+    }
 }
 
 /// Config options for Snarl.
@@ -70,11 +326,11 @@ pub struct SnarlConfig {
     /// Defaults to `false`.
     pub single_select: bool,
 
-    /// Grid size for snapping node positions.
-    /// When `Some(size)`, nodes will snap to a grid with the specified cell size.
+    /// Grid configuration for snapping node positions.
+    /// When `Some(grid)`, nodes will snap to the configured grid.
     /// Set to `None` to disable grid snapping.
     /// Defaults to `None`.
-    pub grid_snap: Option<f32>,
+    pub grid_snap: Option<SnapGrid>,
 
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip_serializing, default))]

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -18,7 +18,7 @@ pub struct SnarlConfig {
     /// Controls key bindings.
 
     /// Action used to draw selection rect.
-    /// Defaults to [`PointerButton::Primary`] && `[Modifiers::SHIFT].
+    /// Defaults to [`PointerButton::Primary`] && [`Modifiers::SHIFT`].
     pub rect_select: ModifierClick,
 
     /// Action used to remove hovered wire.
@@ -62,13 +62,19 @@ pub struct SnarlConfig {
     pub deselect_node: ModifierClick,
 
     /// Action used to click node header.
-    /// Defaults to [`PointerButton::Primary`]``.
+    /// Defaults to [`PointerButton::Primary`].
     pub click_header: ModifierClick,
 
     #[doc(hidden)]
     #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
     /// Do not access other than with .., here to emulate `#[non_exhaustive(pub)]`
     pub _non_exhaustive: (),
+}
+
+impl Default for SnarlConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SnarlConfig {

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1,0 +1,131 @@
+use egui::{Modifiers, PointerButton};
+
+/// Struct holding keyboard modifiers and mouse button.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ModifierClick {
+    /// Keyboard modifiers for this action.
+    pub modifiers: Modifiers,
+
+    /// Mouse buttons for this action.
+    pub mouse_button: PointerButton,
+}
+
+/// Config options for Snarl.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SnarlConfig {
+    /// Controls key bindings.
+
+    /// Action used to draw selection rect.
+    /// Defaults to [`PointerButton::Primary`] && `[Modifiers::SHIFT].
+    pub rect_select: ModifierClick,
+
+    /// Action used to remove hovered wire.
+    /// Defaults to [`PointerButton::Secondary`].
+    pub remove_hovered_wire: ModifierClick,
+
+    /// Action used to deselect all nodes.
+    /// Defaults to [`PointerButton::Primary`].
+    pub deselect_all_nodes: ModifierClick,
+
+    /// Action used to cancel wire drag.
+    /// Defaults to [`PointerButton::Secondary`].
+    pub cancel_wire_drag: ModifierClick,
+
+    /// Action used to click on pin.
+    /// Defaults to [`PointerButton::Secondary`].
+    pub click_pin: ModifierClick,
+
+    /// Action used to drag pin.
+    /// Defaults to [`PointerButton::Primary`] && [`Modifiers::COMMAND`].
+    pub drag_pin: ModifierClick,
+
+    /// Action used to avoid popup menu on wire drop.
+    /// Defaults to [`PointerButton::Primary`] && [`Modifiers::SHIFT`].
+    pub no_menu: ModifierClick,
+
+    /// Action used to click node.
+    /// Defaults to [`PointerButton::Primary`].
+    pub click_node: ModifierClick,
+
+    /// Action used to drag node.
+    /// Defaults to [`PointerButton::Primary`].
+    pub drag_node: ModifierClick,
+
+    /// Action used to select node.
+    /// Defaults to [`PointerButton::Primary`] && [`Modifiers::SHIFT`].
+    pub select_node: ModifierClick,
+
+    /// Action used to deselect node.
+    /// Defaults to [`PointerButton::Primary`] && [`Modifiers::COMMAND`].
+    pub deselect_node: ModifierClick,
+
+    /// Action used to click node header.
+    /// Defaults to [`PointerButton::Primary`]``.
+    pub click_header: ModifierClick,
+
+    #[doc(hidden)]
+    #[cfg_attr(feature = "serde", serde(skip_serializing, default))]
+    /// Do not access other than with .., here to emulate `#[non_exhaustive(pub)]`
+    pub _non_exhaustive: (),
+}
+
+impl SnarlConfig {
+    /// Creates new [`SnarlConfig`] filled with default values.
+    #[must_use]
+    pub const fn new() -> Self {
+        SnarlConfig {
+            rect_select: ModifierClick {
+                modifiers: Modifiers::SHIFT,
+                mouse_button: PointerButton::Primary,
+            },
+            remove_hovered_wire: ModifierClick {
+                modifiers: Modifiers::NONE,
+                mouse_button: PointerButton::Secondary,
+            },
+            deselect_all_nodes: ModifierClick {
+                modifiers: Modifiers::COMMAND,
+                mouse_button: PointerButton::Primary,
+            },
+            cancel_wire_drag: ModifierClick {
+                modifiers: Modifiers::NONE,
+                mouse_button: PointerButton::Secondary,
+            },
+            click_pin: ModifierClick {
+                modifiers: Modifiers::NONE,
+                mouse_button: PointerButton::Secondary,
+            },
+            drag_pin: ModifierClick {
+                modifiers: Modifiers::COMMAND,
+                mouse_button: PointerButton::Primary,
+            },
+            no_menu: ModifierClick {
+                modifiers: Modifiers::SHIFT,
+                mouse_button: PointerButton::Primary,
+            },
+            click_node: ModifierClick {
+                modifiers: Modifiers::NONE,
+                mouse_button: PointerButton::Primary,
+            },
+            drag_node: ModifierClick {
+                modifiers: Modifiers::NONE,
+                mouse_button: PointerButton::Primary,
+            },
+            select_node: ModifierClick {
+                modifiers: Modifiers::SHIFT,
+                mouse_button: PointerButton::Primary,
+            },
+            deselect_node: ModifierClick {
+                modifiers: Modifiers::COMMAND,
+                mouse_button: PointerButton::Primary,
+            },
+            click_header: ModifierClick {
+                modifiers: Modifiers::NONE,
+                mouse_button: PointerButton::Primary,
+            },
+
+            _non_exhaustive: (),
+        }
+    }
+}

--- a/src/ui/pin.rs
+++ b/src/ui/pin.rs
@@ -179,19 +179,19 @@ impl PinInfo {
 
     /// Returns the shape of the pin.
     #[must_use]
-    pub fn get_shape(&self, snarl_style: &SnarlStyle) -> PinShape {
+    pub fn shape(&self, snarl_style: &SnarlStyle) -> PinShape {
         self.shape.unwrap_or_else(|| snarl_style.pin_shape())
     }
 
     /// Returns fill color of the pin.
     #[must_use]
-    pub fn get_fill(&self, snarl_style: &SnarlStyle, style: &Style) -> Color32 {
+    pub fn fill(&self, snarl_style: &SnarlStyle, style: &Style) -> Color32 {
         self.fill.unwrap_or_else(|| snarl_style.pin_fill(style))
     }
 
     /// Returns outline stroke of the pin.
     #[must_use]
-    pub fn get_stroke(&self, snarl_style: &SnarlStyle, style: &Style) -> Stroke {
+    pub fn stroke(&self, snarl_style: &SnarlStyle, style: &Style) -> Stroke {
         self.stroke
             .unwrap_or_else(|| snarl_style.pin_stroke(style))
     }
@@ -207,9 +207,9 @@ impl PinInfo {
         rect: Rect,
         painter: &Painter,
     ) -> PinWireInfo {
-        let shape = self.get_shape(snarl_style);
-        let fill = self.get_fill(snarl_style, style);
-        let stroke = self.get_stroke(snarl_style, style);
+        let shape = self.shape(snarl_style);
+        let fill = self.fill(snarl_style, style);
+        let stroke = self.stroke(snarl_style, style);
         draw_pin(painter, shape, fill, stroke, rect);
 
         PinWireInfo {

--- a/src/ui/pin.rs
+++ b/src/ui/pin.rs
@@ -180,20 +180,20 @@ impl PinInfo {
     /// Returns the shape of the pin.
     #[must_use]
     pub fn get_shape(&self, snarl_style: &SnarlStyle) -> PinShape {
-        self.shape.unwrap_or_else(|| snarl_style.get_pin_shape())
+        self.shape.unwrap_or_else(|| snarl_style.pin_shape())
     }
 
     /// Returns fill color of the pin.
     #[must_use]
     pub fn get_fill(&self, snarl_style: &SnarlStyle, style: &Style) -> Color32 {
-        self.fill.unwrap_or_else(|| snarl_style.get_pin_fill(style))
+        self.fill.unwrap_or_else(|| snarl_style.pin_fill(style))
     }
 
     /// Returns outline stroke of the pin.
     #[must_use]
     pub fn get_stroke(&self, snarl_style: &SnarlStyle, style: &Style) -> Stroke {
         self.stroke
-            .unwrap_or_else(|| snarl_style.get_pin_stroke(style))
+            .unwrap_or_else(|| snarl_style.pin_stroke(style))
     }
 
     /// Draws the pin and returns color.
@@ -214,7 +214,7 @@ impl PinInfo {
 
         PinWireInfo {
             color: self.wire_color.unwrap_or(fill),
-            style: self.wire_style.unwrap_or(snarl_style.get_wire_style()),
+            style: self.wire_style.unwrap_or(snarl_style.wire_style()),
         }
     }
 }

--- a/src/ui/pin.rs
+++ b/src/ui/pin.rs
@@ -1,4 +1,4 @@
-use egui::{epaint::PathShape, pos2, vec2, Color32, Painter, Rect, Shape, Stroke, Style, Vec2};
+use egui::{Color32, Painter, Rect, Shape, Stroke, Style, Vec2, epaint::PathShape, pos2, vec2};
 
 use crate::{InPinId, OutPinId};
 

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -12,6 +12,9 @@ use super::{SnarlWidget, transform_matching_points};
 
 pub type RowHeights = SmallVec<[f32; 8]>;
 
+/// Type alias for column widths (used in vertical layouts).
+pub type ColumnWidths = SmallVec<[f32; 8]>;
+
 /// Node UI state.
 #[derive(Debug)]
 pub struct NodeState {
@@ -22,6 +25,10 @@ pub struct NodeState {
     header_width: f32,
     input_heights: RowHeights,
     output_heights: RowHeights,
+    /// Column widths for input pins in vertical layouts.
+    input_widths: ColumnWidths,
+    /// Column widths for output pins in vertical layouts.
+    output_widths: ColumnWidths,
 
     id: Id,
     dirty: bool,
@@ -34,6 +41,8 @@ struct NodeData {
     header_width: f32,
     input_heights: RowHeights,
     output_heights: RowHeights,
+    input_widths: ColumnWidths,
+    output_widths: ColumnWidths,
 }
 
 impl NodeState {
@@ -49,6 +58,8 @@ impl NodeState {
                 header_width: data.header_width,
                 input_heights: data.input_heights,
                 output_heights: data.output_heights,
+                input_widths: data.input_widths,
+                output_widths: data.output_widths,
                 id,
                 dirty: false,
             },
@@ -70,6 +81,8 @@ impl NodeState {
                         header_width: self.header_width,
                         input_heights: self.input_heights,
                         output_heights: self.output_heights,
+                        input_widths: self.input_widths,
+                        output_widths: self.output_widths,
                     },
                 );
             });
@@ -83,10 +96,7 @@ impl NodeState {
         let width = self.header_width + (self.size.x - self.header_width) * openness;
         Rect::from_min_size(
             pos,
-            egui::vec2(
-                width,
-                f32::max(self.header_height, self.size.y * openness),
-            ),
+            egui::vec2(width, f32::max(self.header_height, self.size.y * openness)),
         )
         .round_ui()
     }
@@ -153,8 +163,34 @@ impl NodeState {
             header_width: spacing.interact_size.x,
             input_heights: SmallVec::new_const(),
             output_heights: SmallVec::new_const(),
+            input_widths: SmallVec::new_const(),
+            output_widths: SmallVec::new_const(),
             id,
             dirty: true,
+        }
+    }
+
+    pub fn input_widths(&self) -> &ColumnWidths {
+        &self.input_widths
+    }
+
+    pub fn output_widths(&self) -> &ColumnWidths {
+        &self.output_widths
+    }
+
+    pub fn set_input_widths(&mut self, input_widths: ColumnWidths) {
+        #[allow(clippy::float_cmp)]
+        if self.input_widths != input_widths {
+            self.input_widths = input_widths;
+            self.dirty = true;
+        }
+    }
+
+    pub fn set_output_widths(&mut self, output_widths: ColumnWidths) {
+        #[allow(clippy::float_cmp)]
+        if self.output_widths != output_widths {
+            self.output_widths = output_widths;
+            self.dirty = true;
         }
     }
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -19,6 +19,7 @@ pub struct NodeState {
     /// It is updated to fit content.
     size: Vec2,
     header_height: f32,
+    header_width: f32,
     input_heights: RowHeights,
     output_heights: RowHeights,
 
@@ -30,6 +31,7 @@ pub struct NodeState {
 struct NodeData {
     size: Vec2,
     header_height: f32,
+    header_width: f32,
     input_heights: RowHeights,
     output_heights: RowHeights,
 }
@@ -44,6 +46,7 @@ impl NodeState {
             |data| NodeState {
                 size: data.size,
                 header_height: data.header_height,
+                header_width: data.header_width,
                 input_heights: data.input_heights,
                 output_heights: data.output_heights,
                 id,
@@ -64,6 +67,7 @@ impl NodeState {
                     NodeData {
                         size: self.size,
                         header_height: self.header_height,
+                        header_width: self.header_width,
                         input_heights: self.input_heights,
                         output_heights: self.output_heights,
                     },
@@ -75,10 +79,12 @@ impl NodeState {
 
     /// Finds node rect at specific position (excluding node frame margin).
     pub fn node_rect(&self, pos: Pos2, openness: f32) -> Rect {
+        // Interpolate width between header_width (collapsed) and full size.x (open)
+        let width = self.header_width + (self.size.x - self.header_width) * openness;
         Rect::from_min_size(
             pos,
             egui::vec2(
-                self.size.x,
+                width,
                 f32::max(self.header_height, self.size.y * openness),
             ),
         )
@@ -104,6 +110,14 @@ impl NodeState {
         #[allow(clippy::float_cmp)]
         if self.header_height != height {
             self.header_height = height;
+            self.dirty = true;
+        }
+    }
+
+    pub fn set_header_width(&mut self, width: f32) {
+        #[allow(clippy::float_cmp)]
+        if self.header_width != width {
+            self.header_width = width;
             self.dirty = true;
         }
     }
@@ -136,6 +150,7 @@ impl NodeState {
         NodeState {
             size: spacing.interact_size,
             header_height: spacing.interact_size.y,
+            header_width: spacing.interact_size.x,
             input_heights: SmallVec::new_const(),
             output_heights: SmallVec::new_const(),
             id,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -630,8 +630,8 @@ impl SnarlWidget {
     /// Use same `Ui` instance that was used in [`SnarlWidget::show`].
     #[must_use]
     #[inline]
-    pub fn get_selected_nodes(self, ui: &Ui) -> Vec<NodeId> {
-        self.get_selected_nodes_at(ui.id(), ui.ctx())
+    pub fn selected_nodes(self, ui: &Ui) -> Vec<NodeId> {
+        self.selected_nodes_at(ui.id(), ui.ctx())
     }
 
     /// Returns list of nodes selected in the UI for the `SnarlWidget` with same id.
@@ -639,7 +639,7 @@ impl SnarlWidget {
     /// `ui_id` must be the Id of the `Ui` instance that was used in [`SnarlWidget::show`].
     #[must_use]
     #[inline]
-    pub fn get_selected_nodes_at(self, ui_id: Id, ctx: &Context) -> Vec<NodeId> {
+    pub fn selected_nodes_at(self, ui_id: Id, ctx: &Context) -> Vec<NodeId> {
         let snarl_id = self.get_id(ui_id);
 
         ctx.data(|d| d.get_temp::<SelectedNodes>(snarl_id).unwrap_or_default().0)
@@ -650,10 +650,10 @@ impl SnarlWidget {
 /// Returns nodes selected in the UI for the `SnarlWidget` with same ID.
 ///
 /// Only works if [`SnarlWidget::id`] was used.
-/// For other cases construct [`SnarlWidget`] and use [`SnarlWidget::get_selected_nodes`] or [`SnarlWidget::get_selected_nodes_at`].
+/// For other cases construct [`SnarlWidget`] and use [`SnarlWidget::selected_nodes`] or [`SnarlWidget::selected_nodes_at`].
 #[must_use]
 #[inline]
-pub fn get_selected_nodes(id: Id, ctx: &Context) -> Vec<NodeId> {
+pub fn selected_nodes(id: Id, ctx: &Context) -> Vec<NodeId> {
     ctx.data(|d| d.get_temp::<SelectedNodes>(id).unwrap_or_default().0)
         .into_vec()
 }

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -237,6 +237,27 @@ pub trait SnarlViewer<T> {
         let _ = (node, inputs, outputs, ui, snarl);
     }
 
+    /// Returns optional waypoints for a wire to route through.
+    ///
+    /// Override this method to specify intermediate waypoints for wires,
+    /// allowing for custom wire routing (e.g., to avoid crossing other nodes).
+    ///
+    /// Note: This is a hook for future wire routing customization. Currently,
+    /// for complex wire routing, you can hide the default wire using `wire_style`
+    /// and draw custom wire segments in [`draw_foreground`].
+    ///
+    /// By default returns `None` (direct wire using default rendering).
+    #[inline]
+    fn wire_waypoints(
+        &mut self,
+        from: &OutPinId,
+        to: &InPinId,
+        snarl: &Snarl<T>,
+    ) -> Option<Vec<Pos2>> {
+        let _ = (from, to, snarl);
+        None
+    }
+
     /// Checks if wire has something to show in widget.
     /// This may not be called if wire is invisible.
     #[inline]
@@ -393,6 +414,35 @@ pub trait SnarlViewer<T> {
         snarl: &Snarl<T>,
     ) {
         let _ = (viewport, snarl_style, style, painter, snarl);
+    }
+
+    /// Called to compute automatic layout positions for nodes.
+    ///
+    /// Override this method to implement automatic layout algorithms
+    /// (e.g., force-directed, hierarchical, tree layouts).
+    ///
+    /// Return a map of node IDs to their new positions. Only nodes present
+    /// in the returned map will be repositioned.
+    ///
+    /// This method is called when [`apply_layout`](Self::apply_layout) returns true.
+    ///
+    /// By default returns an empty map (no layout changes).
+    #[inline]
+    fn compute_layout(&mut self, snarl: &Snarl<T>) -> std::collections::HashMap<NodeId, Pos2> {
+        let _ = snarl;
+        std::collections::HashMap::new()
+    }
+
+    /// Returns whether to apply automatic layout this frame.
+    ///
+    /// Override this method to trigger layout computation based on user input
+    /// (e.g., a button press) or other conditions.
+    ///
+    /// By default returns false (no automatic layout).
+    #[inline]
+    fn apply_layout(&mut self, snarl: &Snarl<T>) -> bool {
+        let _ = snarl;
+        false
     }
 
     /// Informs the viewer what is the current transform of the snarl view

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -352,4 +352,15 @@ pub trait SnarlViewer<T> {
     fn current_transform(&mut self, to_global: &mut TSTransform, snarl: &mut Snarl<T>) {
         let _ = (to_global, snarl);
     }
+
+    /// Allows last-minute updates to the selected nodes.
+    ///
+    /// This method is called at the beginning of graph rendering.
+    /// Return `Some(Vec<NodeId>)` to override the current selection,
+    /// or `None` to keep the current selection unchanged.
+    #[inline]
+    fn update_selection(&mut self, selected_nodes: &[NodeId]) -> Option<Vec<NodeId>> {
+        let _ = selected_nodes;
+        None
+    }
 }

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -320,6 +320,17 @@ pub trait SnarlViewer<T> {
         snarl.drop_inputs(pin.id);
     }
 
+    /// Called when a node has been moved (dragged to a new position).
+    ///
+    /// This callback is invoked after the node's position has been updated in the snarl.
+    /// Override this method to react to node position changes without polling.
+    ///
+    /// The `new_pos` parameter contains the node's new position in graph coordinates.
+    #[inline]
+    fn node_moved(&mut self, node: NodeId, new_pos: Pos2, snarl: &mut Snarl<T>) {
+        let _ = (node, new_pos, snarl);
+    }
+
     /// Draws background of the snarl view.
     ///
     /// By default it draws the background pattern using [`BackgroundPattern::draw`].

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -105,7 +105,8 @@ pub trait SnarlViewer<T> {
     ///
     /// This is the good place to show the node's title and controls related to the whole node.
     ///
-    /// By default it shows the node's title.
+    /// By default it shows the node's title on the left and calls [`show_header_buttons`]
+    /// on the right side.
     #[inline]
     fn show_header(
         &mut self,
@@ -115,8 +116,30 @@ pub trait SnarlViewer<T> {
         ui: &mut Ui,
         snarl: &mut Snarl<T>,
     ) {
-        let _ = (inputs, outputs);
-        ui.label(self.title(&snarl[node]));
+        ui.horizontal(|ui| {
+            ui.label(self.title(&snarl[node]));
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                self.show_header_buttons(node, inputs, outputs, ui, snarl);
+            });
+        });
+    }
+
+    /// Renders buttons/icons in the node's header (right side by default).
+    ///
+    /// Override this method to add custom buttons, flags, or status icons to nodes.
+    /// This is useful for Houdini-style node flags (template, preview, bypass, etc.).
+    ///
+    /// By default this method does nothing.
+    #[inline]
+    fn show_header_buttons(
+        &mut self,
+        node: NodeId,
+        inputs: &[InPin],
+        outputs: &[OutPin],
+        ui: &mut Ui,
+        snarl: &mut Snarl<T>,
+    ) {
+        let _ = (node, inputs, outputs, ui, snarl);
     }
 
     /// Returns number of input pins of the node.

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -359,6 +359,7 @@ pub trait SnarlViewer<T> {
     /// By default it draws the background pattern using [`BackgroundPattern::draw`].
     ///
     /// If you want to draw the background yourself, you can override this method.
+    /// This is also a good place to draw grouping rectangles behind nodes.
     #[inline]
     fn draw_background(
         &mut self,
@@ -374,6 +375,24 @@ pub trait SnarlViewer<T> {
         if let Some(background) = background {
             background.draw(viewport, snarl_style, style, painter);
         }
+    }
+
+    /// Draws foreground elements on top of nodes and wires.
+    ///
+    /// Override this method to draw comments, annotations, overlays, or any
+    /// custom elements that should appear on top of the graph.
+    ///
+    /// By default this method does nothing.
+    #[inline]
+    fn draw_foreground(
+        &mut self,
+        viewport: &Rect,
+        snarl_style: &SnarlStyle,
+        style: &Style,
+        painter: &Painter,
+        snarl: &Snarl<T>,
+    ) {
+        let _ = (viewport, snarl_style, style, painter, snarl);
     }
 
     /// Informs the viewer what is the current transform of the snarl view

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -4,7 +4,7 @@ use crate::{InPin, InPinId, NodeId, OutPin, OutPinId, Snarl};
 
 use super::{
     BackgroundPattern, NodeLayout, SnarlStyle,
-    pin::{AnyPins, SnarlPin},
+    pin::{AnyPins, PinContext, SnarlPin},
 };
 
 /// `SnarlViewer` is a trait for viewing a Snarl.
@@ -148,10 +148,15 @@ pub trait SnarlViewer<T> {
     fn inputs(&mut self, node: &T) -> usize;
 
     /// Renders one specified node's input element and returns drawer for the corresponding pin.
+    ///
+    /// The `context` parameter provides information about the current UI state,
+    /// including whether the label should be visible based on [`SnarlStyle::pin_label_visibility`].
+    /// Use `context.label_visible` to conditionally show or hide the pin's label.
     fn show_input(
         &mut self,
         pin: &InPin,
         ui: &mut Ui,
+        context: PinContext,
         snarl: &mut Snarl<T>,
     ) -> impl SnarlPin + 'static;
 
@@ -161,10 +166,15 @@ pub trait SnarlViewer<T> {
     fn outputs(&mut self, node: &T) -> usize;
 
     /// Renders the node's output.
+    ///
+    /// The `context` parameter provides information about the current UI state,
+    /// including whether the label should be visible based on [`SnarlStyle::pin_label_visibility`].
+    /// Use `context.label_visible` to conditionally show or hide the pin's label.
     fn show_output(
         &mut self,
         pin: &OutPin,
         ui: &mut Ui,
+        context: PinContext,
         snarl: &mut Snarl<T>,
     ) -> impl SnarlPin + 'static;
 

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -1,10 +1,10 @@
-use egui::{emath::TSTransform, Painter, Pos2, Rect, Style, Ui};
+use egui::{Painter, Pos2, Rect, Style, Ui, emath::TSTransform};
 
 use crate::{InPin, InPinId, NodeId, OutPin, OutPinId, Snarl};
 
 use super::{
-    pin::{AnyPins, SnarlPin},
     BackgroundPattern, NodeLayout, SnarlStyle,
+    pin::{AnyPins, SnarlPin},
 };
 
 /// `SnarlViewer` is a trait for viewing a Snarl.

--- a/src/ui/wire.rs
+++ b/src/ui/wire.rs
@@ -685,7 +685,7 @@ impl CacheTrait for WiresCache {
 }
 
 impl WiresCache {
-    pub fn get_3(&mut self, wire: WireId, args: WireArgs) -> &mut WireCache3 {
+    pub fn bezier_3(&mut self, wire: WireId, args: WireArgs) -> &mut WireCache3 {
         let cached = self.bezier_3.entry(wire).or_default();
 
         cached.generation = self.generation;
@@ -705,7 +705,7 @@ impl WiresCache {
         cached
     }
 
-    pub fn get_5(&mut self, wire: WireId, args: WireArgs) -> &mut WireCache5 {
+    pub fn bezier_5(&mut self, wire: WireId, args: WireArgs) -> &mut WireCache5 {
         let cached = self.bezier_5.entry(wire).or_default();
 
         cached.generation = self.generation;
@@ -726,7 +726,7 @@ impl WiresCache {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn get_aa(&mut self, wire: WireId, args: WireArgs) -> &mut WireCacheAA {
+    pub fn axis_aligned(&mut self, wire: WireId, args: WireArgs) -> &mut WireCacheAA {
         let cached = self.axis_aligned.entry(wire).or_default();
 
         cached.generation = self.generation;
@@ -759,7 +759,7 @@ fn draw_bezier_3(
     let clip_rect = ui.clip_rect();
 
     ui.memory_mut(|m| {
-        let cached = m.caches.cache::<WiresCache>().get_3(wire, args);
+        let cached = m.caches.cache::<WiresCache>().bezier_3(wire, args);
 
         if cached.aabb.intersects(clip_rect) {
             shapes.push(Shape::line(cached.line(threshold), stroke));
@@ -800,7 +800,7 @@ fn draw_bezier_5(
     let clip_rect = ui.clip_rect();
 
     ui.memory_mut(|m| {
-        let cached = m.caches.cache::<WiresCache>().get_5(wire, args);
+        let cached = m.caches.cache::<WiresCache>().bezier_5(wire, args);
 
         if cached.aabb.intersects(clip_rect) {
             shapes.push(Shape::line(cached.line(threshold), stroke));
@@ -918,7 +918,7 @@ fn hit_wire_bezier_3(
     hit_threshold: f32,
 ) -> bool {
     let (aabb, points) = ctx.memory_mut(|m| {
-        let cache = m.caches.cache::<WiresCache>().get_3(wire, args);
+        let cache = m.caches.cache::<WiresCache>().bezier_3(wire, args);
 
         (cache.aabb, cache.points)
     });
@@ -1005,7 +1005,7 @@ fn hit_wire_bezier_5(
     hit_threshold: f32,
 ) -> bool {
     let (aabb, points) = ctx.memory_mut(|m| {
-        let cache = m.caches.cache::<WiresCache>().get_5(wire, args);
+        let cache = m.caches.cache::<WiresCache>().bezier_5(wire, args);
 
         (cache.aabb, cache.points)
     });
@@ -1214,7 +1214,7 @@ fn hit_wire_axis_aligned(
     hit_threshold: f32,
 ) -> bool {
     let aawire = ctx.memory_mut(|m| {
-        let cache = m.caches.cache::<WiresCache>().get_aa(wire, args);
+        let cache = m.caches.cache::<WiresCache>().axis_aligned(wire, args);
 
         cache.aawire
     });
@@ -1292,7 +1292,7 @@ fn draw_axis_aligned(
 
     let clip_rect = ui.clip_rect();
     ui.memory_mut(|m| {
-        let cached = m.caches.cache::<WiresCache>().get_aa(wire, args);
+        let cached = m.caches.cache::<WiresCache>().axis_aligned(wire, args);
 
         if cached.aawire.aabb.intersects(clip_rect) {
             shapes.push(Shape::line(cached.line(threshold), stroke));


### PR DESCRIPTION
This PR consolidates several open pull requests:

Merged PRs:

1. Wire Widget Support (#79).
2. Configurable Input System (#72).
3. Left-Click Wire Disconnect (#75).
4. Escape Key Deselection (#55).

Changes:

- Added `src/ui/config.rs` with `SnarlConfig` and `ModifierClick` for configurable controls.
- Better wire interaction with widget support and configurable disconnect actions.
- Better input handling with escape key support for node deselection.
- Made `clippy` happy.
- Bumped deps.

Notes:

- PR #78 was skipped as it was superseded by #79.
- PR #23 was not included due to extensive conflicts with the current codebase.
- All changes compile cleanly with no warnings.
