### PR TITLE
pass NodeId and &Snarl reference to SnarlViewer::{inputs, outputs}

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -157,7 +157,7 @@ impl SnarlViewer<DemoNode> for DemoViewer {
         }
     }
 
-    fn inputs(&mut self, node: &DemoNode) -> usize {
+    fn inputs(&mut self, node: &DemoNode, _snarl: &Snarl<DemoNode>) -> usize {
         match node {
             DemoNode::Sink | DemoNode::ShowImage(_) => 1,
             DemoNode::Number(_) | DemoNode::String(_) => 0,
@@ -165,7 +165,7 @@ impl SnarlViewer<DemoNode> for DemoViewer {
         }
     }
 
-    fn outputs(&mut self, node: &DemoNode) -> usize {
+    fn outputs(&mut self, node: &DemoNode, _snarl: &Snarl<DemoNode>) -> usize {
         match node {
             DemoNode::Sink => 0,
             DemoNode::Number(_)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1780,12 +1780,12 @@ where
     let Node {
         pos,
         open,
-        ref value,
+        ..
     } = snarl.nodes[node.0];
 
     // Collect pins
-    let inputs_count = viewer.inputs(value);
-    let outputs_count = viewer.outputs(value);
+    let inputs_count = viewer.inputs(node, snarl);
+    let outputs_count = viewer.outputs(node, snarl);
 
     let inputs = (0..inputs_count)
         .map(|idx| InPin::new(snarl, InPinId { node, input: idx }))

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -122,7 +122,7 @@ pub trait SnarlViewer<T> {
     /// Returns number of input pins of the node.
     ///
     /// [`SnarlViewer::show_input`] will be called for each input in range `0..inputs()`.
-    fn inputs(&mut self, node: &T) -> usize;
+    fn inputs(&mut self, node: NodeId, snarl: &Snarl<T>) -> usize;
 
     /// Renders one specified node's input element and returns drawer for the corresponding pin.
     fn show_input(
@@ -135,7 +135,7 @@ pub trait SnarlViewer<T> {
     /// Returns number of output pins of the node.
     ///
     /// [`SnarlViewer::show_output`] will be called for each output in range `0..outputs()`.
-    fn outputs(&mut self, node: &T) -> usize;
+    fn outputs(&mut self, node: NodeId, snarl: &Snarl<T>) -> usize;
 
     /// Renders the node's output.
     fn show_output(


### PR DESCRIPTION
This allows making the number of input/output pins dependent on the (types of) connections the node currently has.

For example a "sum" node can always have "one more" input than its current connections, or a "split vector" node can present different numbers of outputs depending on the incoming type.