### PR TITLE
Method to update node selection

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,7 +34,7 @@ use self::{
 pub use self::{
     background_pattern::{BackgroundPattern, Grid},
     pin::{AnyPins, PinInfo, PinShape, PinWireInfo, SnarlPin},
-    state::get_selected_nodes,
+    state::{get_selected_nodes, update_selected_nodes},
     viewer::SnarlViewer,
     wire::{WireLayer, WireStyle},
 };

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -610,6 +610,15 @@ impl SnarlWidget {
         ctx.data(|d| d.get_temp::<SelectedNodes>(snarl_id).unwrap_or_default().0)
             .into_vec()
     }
+
+    /// Modifies the node selection in the UI for the `SnarlWidget` with same ID.
+    ///
+    /// Use same `Ui` instance that was used in [`SnarlWidget::show`].
+    #[inline]
+    pub fn update_selected_nodes(self, ui: &Ui, f: impl FnOnce(&mut Vec<NodeId>)) {
+        let snarl_id = self.get_id(ui.id());
+        update_selected_nodes(snarl_id, ui.ctx(), f);
+    }
 }
 
 /// Returns nodes selected in the UI for the `SnarlWidget` with same ID.
@@ -621,4 +630,16 @@ impl SnarlWidget {
 pub fn get_selected_nodes(id: Id, ctx: &Context) -> Vec<NodeId> {
     ctx.data(|d| d.get_temp::<SelectedNodes>(id).unwrap_or_default().0)
         .into_vec()
+}
+
+/// Modifies the node selection in the UI for the `SnarlWidget` with same ID.
+///
+/// Only works if [`SnarlWidget::id`] was used.
+pub fn update_selected_nodes(id: Id, ctx: &Context, f: impl FnOnce(&mut Vec<NodeId>)) {
+    ctx.data_mut(|data| {
+        let selection = data.get_temp_mut_or_default::<SelectedNodes>(id);
+        let mut nodes = std::mem::take(&mut selection.0).into_vec();
+        f(&mut nodes);
+        selection.0 = SmallVec::from_vec(nodes);
+    });
 }


### PR DESCRIPTION
A simple change, modeled after and using egui's data_mut to allow to updating the selection via the widget.

This is useful if you want to clear the selection when inserting new nodes or selecting a set of bulk created nodes (e.g. via pasting/importing).