### PR TITLE
Add `ui` crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,16 +37,18 @@ keywords = ["egui", "node", "graph", "ui", "node-graph"]
 categories = ["gui", "visualization"]
 
 [features]
+default = ["ui"]
 serde = ["dep:serde", "egui/serde", "slab/serde"]
+ui = ["dep:egui", "dep:egui-scale"]
 
 [dependencies]
-egui.workspace = true
+egui = { workspace = true, optional = true }
 slab = { version = "0.4" }
 serde = { workspace = true, features = ["derive"], optional = true }
 smallvec = { version = "1.15", features = ["const_new"] }
 
 egui-probe = { workspace = true, features = ["derive"], optional = true }
-egui-scale.workspace = true
+egui-scale = { workspace = true, optional = true }
 
 [dev-dependencies]
 eframe = { workspace = true, features = ["serde", "persistence"] }
@@ -59,4 +61,4 @@ wasm-bindgen-futures.workspace = true
 
 [[example]]
 name = "demo"
-required-features = ["serde", "egui-probe"]
+required-features = ["ui", "serde", "egui-probe"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ categories = ["gui", "visualization"]
 
 [features]
 default = ["ui"]
-serde = ["dep:serde", "egui/serde", "slab/serde"]
+serde = ["dep:serde", "egui?/serde", "slab/serde"]
 ui = ["dep:egui", "dep:egui-scale"]
 
 [dependencies]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -428,23 +428,23 @@ impl SnarlViewer<DemoNode> for DemoViewer {
     fn show_graph_menu(&mut self, pos: egui::Pos2, ui: &mut Ui, snarl: &mut Snarl<DemoNode>) {
         ui.label("Add node");
         if ui.button("Number").clicked() {
-            snarl.insert_node(pos, DemoNode::Number(0.0));
+            snarl.insert_node(pos.into(), DemoNode::Number(0.0));
             ui.close();
         }
         if ui.button("Expr").clicked() {
-            snarl.insert_node(pos, DemoNode::ExprNode(ExprNode::new()));
+            snarl.insert_node(pos.into(), DemoNode::ExprNode(ExprNode::new()));
             ui.close();
         }
         if ui.button("String").clicked() {
-            snarl.insert_node(pos, DemoNode::String(String::new()));
+            snarl.insert_node(pos.into(), DemoNode::String(String::new()));
             ui.close();
         }
         if ui.button("Show image").clicked() {
-            snarl.insert_node(pos, DemoNode::ShowImage(String::new()));
+            snarl.insert_node(pos.into(), DemoNode::ShowImage(String::new()));
             ui.close();
         }
         if ui.button("Sink").clicked() {
-            snarl.insert_node(pos, DemoNode::Sink);
+            snarl.insert_node(pos.into(), DemoNode::Sink);
             ui.close();
         }
     }
@@ -516,7 +516,7 @@ impl SnarlViewer<DemoNode> for DemoViewer {
                 for (name, ctor, in_ty) in dst_in_candidates {
                     if src_out_ty & in_ty != 0 && ui.button(name).clicked() {
                         // Create new node.
-                        let new_node = snarl.insert_node(pos, ctor());
+                        let new_node = snarl.insert_node(pos.into(), ctor());
                         let dst_pin = InPinId {
                             node: new_node,
                             input: 0,
@@ -550,7 +550,7 @@ impl SnarlViewer<DemoNode> for DemoViewer {
                         let new_node = ctor();
                         let dst_ty = pin_out_compat(&new_node);
 
-                        let new_node = snarl.insert_node(pos, new_node);
+                        let new_node = snarl.insert_node(pos.into(), new_node);
                         let dst_pin = OutPinId {
                             node: new_node,
                             output: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ impl NodePos {
     }
 }
 
+impl Eq for NodePos {}
+
 #[cfg(feature = "ui")]
 impl Into<egui::Pos2> for NodePos {
     fn into(self) -> egui::Pos2 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1393,11 +1393,11 @@ where
         if snarl_state.selected_nodes().contains(&node) {
             for node in snarl_state.selected_nodes() {
                 let node = &mut snarl.nodes[node.0];
-                node.pos += delta;
+                node.pos = (Into::<egui::Pos2>::into(node.pos) + delta).into();
             }
         } else {
             let node = &mut snarl.nodes[node.0];
-            node.pos += delta;
+            node.pos = (Into::<egui::Pos2>::into(node.pos) + delta).into();
         }
     }
 
@@ -1795,7 +1795,7 @@ where
         .map(|idx| OutPin::new(snarl, OutPinId { node, output: idx }))
         .collect::<Vec<_>>();
 
-    let node_pos = pos.round_ui();
+    let node_pos = Into::<egui::Pos2>::into(pos).round_ui();
 
     // Generate persistent id for the node.
     let node_id = snarl_id.with(("snarl-node", node));

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -280,7 +280,7 @@ impl SnarlState {
         let mut bb = Rect::NOTHING;
 
         for (_, node) in &snarl.nodes {
-            bb.extend_with(node.pos);
+            bb.extend_with(node.pos.into());
         }
 
         if bb.is_finite() {


### PR DESCRIPTION
This new crate feature (enabled by default), allows disabling the ui/graphical parts of the crate. It is useful for applications only caring about the `Snarl` struct and methods, not the `SnarlViewer` part.

Please note that for achieving this, I had to first use `std::collections::HashSet` instead of the egui provided `egui::ahash::HashSet`. I guess that does not change a lot. And if it's really needed then we can add the `ahash` crate explicit dependency. 
Also, I created a new `NodePos` struct to stop reliying on `egui::Pos2`. It is very minimal and performs math operations by calling `Into<egui::Pos2>::into(node_pos)` and `From<egui::Pos2>::from(egui_pos)`.

What are your opinions on these changes?