### PR TITLE
Add nodes_moved method to SnarlViewer

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -795,7 +795,7 @@ impl Default for SnarlStyle {
 }
 
 struct DrawNodeResponse {
-    node_moved: Option<(NodeId, Vec2)>,
+    node_moved: Option<(NodeId, Vec2, bool)>,
     node_to_top: Option<NodeId>,
     drag_released: bool,
     pin_hovered: Option<AnyPin>,
@@ -1386,24 +1386,33 @@ where
         snarl_state.node_to_top(node);
     }
 
-    if let Some((node, delta)) = node_moved
-        && snarl.nodes.contains(node.0)
-    {
-        ui.ctx().request_repaint();
-        if snarl_state.selected_nodes().contains(&node) {
-            for node in snarl_state.selected_nodes() {
-                let node = &mut snarl.nodes[node.0];
-                node.pos += delta;
+    if let Some((node_id, delta, finished)) = node_moved {
+        if snarl.nodes.contains(node_id.0) {
+            ui.ctx().request_repaint();
+            if snarl_state.selected_nodes().contains(&node_id) {
+                move_nodes(snarl_state.selected_nodes(), delta, finished, snarl, viewer);
+            } else {
+                move_nodes(&[node_id], delta, finished, snarl, viewer);
             }
-        } else {
-            let node = &mut snarl.nodes[node.0];
-            node.pos += delta;
         }
     }
 
     snarl_state.store(snarl, ui.ctx());
 
     snarl_resp
+}
+
+fn move_nodes<T, V: SnarlViewer<T>>(
+    nodes: &[NodeId],
+    delta: Vec2,
+    finished: bool,
+    snarl: &mut Snarl<T>,
+    viewer: &mut V,
+) {
+    for node_id in nodes {
+        snarl.nodes[node_id.0].pos += delta;
+    }
+    viewer.nodes_moved(nodes, delta, finished, snarl);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1859,8 +1868,12 @@ where
         Sense::click_and_drag(),
     );
 
-    if !modifiers.shift && !modifiers.command && r.dragged_by(PointerButton::Primary) {
-        node_moved = Some((node, r.drag_delta()));
+    let drag_stopped = r.drag_stopped_by(PointerButton::Primary);
+    if !modifiers.shift
+        && !modifiers.command
+        && (r.dragged_by(PointerButton::Primary) || drag_stopped)
+    {
+        node_moved = Some((node, r.drag_delta(), drag_stopped));
     }
 
     if r.clicked_by(PointerButton::Primary) || r.dragged_by(PointerButton::Primary) {

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -1,10 +1,10 @@
-use egui::{emath::TSTransform, Painter, Pos2, Rect, Style, Ui};
+use egui::{Painter, Pos2, Rect, Style, Ui, Vec2, emath::TSTransform};
 
 use crate::{InPin, InPinId, NodeId, OutPin, OutPinId, Snarl};
 
 use super::{
-    pin::{AnyPins, SnarlPin},
     BackgroundPattern, NodeLayout, SnarlStyle,
+    pin::{AnyPins, SnarlPin},
 };
 
 /// `SnarlViewer` is a trait for viewing a Snarl.
@@ -340,6 +340,20 @@ pub trait SnarlViewer<T> {
         if let Some(background) = background {
             background.draw(viewport, snarl_style, style, painter);
         }
+    }
+
+    /// Informs the viewer that nodes were moved.
+    ///
+    /// Called each frame during a drag with the frame's `delta`, after Snarl node positions were updated.
+    /// When `drag_finished` is `true`, this is the final call for this drag gesture.
+    fn nodes_moved(
+        &mut self,
+        nodes: &[NodeId],
+        delta: Vec2,
+        drag_finished: bool,
+        snarl: &mut Snarl<T>,
+    ) {
+        let _ = (nodes, delta, drag_finished, snarl);
     }
 
     /// Informs the viewer what is the current transform of the snarl view


### PR DESCRIPTION
Support for moving multiple selected nodes with single drag.

Tested manually, with the following code.

```
fn nodes_moved(&mut self, nodes: &[NodeId], _delta: Vec2, drag_finished: bool, snarl: &mut Snarl<SnarlNode>) {
    if !drag_finished {
        return;
    }
    let positions: Vec<_> = nodes
        .iter()
        .filter_map(|&node| {
            let info = snarl.get_node_info(node)?;
            let component_ref = snarl[node].component_ref;
            self.session_state.ref_component_weak(component_ref)?;
            Some((component_ref, (info.pos.x, info.pos.y)))
        })
        .collect();
    if !positions.is_empty() {
        self.state_control.set_component_positions(positions);
    }
}
```