### PR TITLE
Upgrade egui to v0.34

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install MSRV
-      run: rustup install 1.88
+      run: rustup install 1.92
     - name: Test on MSRV
-      run: cargo +1.88 test
+      run: cargo +1.92 test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,22 +4,22 @@ members = ["demo"]
 resolver = "3"
 
 [workspace.package]
-rust-version = "1.88"
+rust-version = "1.92"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/egui-snarl"
 repository = "https://github.com/zakarumych/egui-snarl"
 
 [workspace.dependencies]
-egui = { version = "0.33" }
-eframe = { version = "0.33" }
-egui_extras = { version = "0.33" }
+egui = { version = "0.34" }
+eframe = { version = "0.34" }
+egui_extras = { version = "0.34" }
 syn = { version = "2" }
 serde = { version = "1" }
 serde_json = { version = "1" }
 
-egui-probe = { version = "0.10.0" }
-egui-scale = { version = "0.3.0" }
+egui-probe = { version = "0.11.0" }
+egui-scale = { version = "0.4.0" }
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3.81"
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -965,7 +965,8 @@ impl DemoApp {
     pub fn new(cx: &CreationContext) -> Self {
         egui_extras::install_image_loaders(&cx.egui_ctx);
 
-        cx.egui_ctx.style_mut(|style| style.animation_time *= 10.0);
+        cx.egui_ctx
+            .global_style_mut(|style| style.animation_time *= 10.0);
 
         let snarl = cx.storage.map_or_else(Snarl::new, |storage| {
             storage
@@ -988,8 +989,8 @@ impl DemoApp {
 }
 
 impl App for DemoApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::Panel::top("top_panel").show_inside(ui, |ui| {
             // The top panel is often a good place for a menu bar:
 
             egui::MenuBar::new().ui(ui, |ui| {
@@ -997,7 +998,7 @@ impl App for DemoApp {
                 {
                     ui.menu_button("File", |ui| {
                         if ui.button("Quit").clicked() {
-                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                            ui.send_viewport_cmd(egui::ViewportCommand::Close);
                         }
                     });
                     ui.add_space(16.0);
@@ -1011,13 +1012,13 @@ impl App for DemoApp {
             });
         });
 
-        egui::SidePanel::left("style").show(ctx, |ui| {
+        egui::Panel::left("style").show_inside(ui, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 egui_probe::Probe::new(&mut self.style).show(ui);
             });
         });
 
-        egui::SidePanel::right("selected-list").show(ctx, |ui| {
+        egui::Panel::right("selected-list").show_inside(ui, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 ui.strong("Selected nodes");
 
@@ -1049,7 +1050,7 @@ impl App for DemoApp {
             });
         });
 
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
             SnarlWidget::new()
                 .id(Id::new("snarl-demo"))
                 .style(self.style)

--- a/src/ui/wire.rs
+++ b/src/ui/wire.rs
@@ -678,10 +678,6 @@ impl CacheTrait for WiresCache {
     fn len(&self) -> usize {
         self.bezier_3.len() + self.bezier_5.len() + self.axis_aligned.len()
     }
-
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
 }
 
 impl WiresCache {


### PR DESCRIPTION
Also raises MSRV to 1.92 inline with upstream `egui`.

Blocked by:

- [x] https://github.com/zakarumych/egui-probe/pull/27
- [x] https://github.com/zakarumych/egui-scale/pull/4
- [x] Use crates.io release for `egui-probe` and `egui-scale`